### PR TITLE
Agrega tilde faltante a periocididad 'cada 15 días'

### DIFF
--- a/pydatajson/schemas/accrualPeriodicity.json
+++ b/pydatajson/schemas/accrualPeriodicity.json
@@ -41,7 +41,7 @@
   },
   {
     "id": "R/P0.5M",
-    "description": "Cada 15 dias"
+    "description": "Cada 15 días"
   },
   {
     "id": "R/P0.33M",


### PR DESCRIPTION
closes #58 
El archivo del que se tomó esta lista de frecuencias (https://github.com/datosgobar/paquete-apertura-datos/blob/master/standards/metadata/accrualPeriodicity.json) tiene una tilde faltante. Esto está generando problemas en la validación de datasets del Ministerio de Justicia como se describe en #58 

@abenassi este cambio es un impedimento para la correcta federación del portal de datos de Justicia. Requerimos una nueva versión de pydatajson disponible en PyPI, para luego actualizar las dependencias de `libreria-catalogos` en el servidor de federación, y que el data.json generado para Justicia sea del todo correcto. Se podrá empujar durante el día de hoy?