### PR TITLE
Mejoras datasets no federados

### DIFF
--- a/pydatajson/core.py
+++ b/pydatajson/core.py
@@ -929,6 +929,7 @@ El reporte no contiene la clave obligatoria {}. Pruebe con otro archivo.
         central_catalog = readers.read_catalog(central_catalog)
         federados = 0  # En ambos catálogos
         no_federados = 0
+        datasets_no_federados = []
 
         # Lo busco uno por uno a ver si está en la lista de catálogos
         for dataset in catalog.get('dataset', []):
@@ -940,6 +941,8 @@ El reporte no contiene la clave obligatoria {}. Pruebe con otro archivo.
                     break
             if not found:
                 no_federados += 1
+                datasets_no_federados.append((dataset.get('title'),
+                                              dataset.get('landingPage')))
 
         if federados or no_federados:  # Evita división por 0
             federados_pct = 100 * float(federados) / (federados + no_federados)
@@ -949,6 +952,7 @@ El reporte no contiene la clave obligatoria {}. Pruebe con otro archivo.
         result = {
             'datasets_federados_cant': federados,
             'datasets_no_federados_cant': no_federados,
+            'datasets_no_federados': datasets_no_federados,
             'datasets_federados_pct': round(federados_pct, 2)
         }
         return result

--- a/pydatajson/core.py
+++ b/pydatajson/core.py
@@ -683,7 +683,7 @@ el argumento 'report'. Por favor, intentelo nuevamente.""")
 
 - **Cantidad de Datasets Federados**: {federated_datasets}
 - **Cantidad de Datasets NO Federados**: {not_federated_datasets}
-- **Porcentaje de Datasets NO Federados"": {not_federated_datasets_pct}%
+- **Porcentaje de Datasets NO Federados**: {not_federated_datasets_pct}%
 
 ## Datasets no federados:
 

--- a/pydatajson/core.py
+++ b/pydatajson/core.py
@@ -1017,7 +1017,7 @@ El reporte no contiene la clave obligatoria {}. Pruebe con otro archivo.
                 other_value = helpers.traverse_dict(other, field)
             else:
                 value = dataset.get(field)
-                other_value = dataset.get(field)
+                other_value = other.get(field)
 
             if value != other_value:
                 return False

--- a/pydatajson/core.py
+++ b/pydatajson/core.py
@@ -26,6 +26,7 @@ from . import helpers
 from . import writers
 
 ABSOLUTE_PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
+CENTRAL_CATALOG = "http://datos.gob.ar/data.json"
 
 
 class DataJson(object):
@@ -630,7 +631,9 @@ el argumento 'report'. Por favor, intentelo nuevamente.""")
         metadatos generales de un catálogo (título, editor, fecha de
         publicación, et cetera), junto con:
             - estado de los metadatos a nivel catálogo,
-            - estado global de los metadatos, y
+            - estado global de los metadatos,
+            - cantidad de datasets federados y no federados,
+            - detalles de los datasets no federados
             - cantidad de datasets y distribuciones incluidas
 
         Es utilizada por la rutina diaria de `libreria-catalogos` para generar
@@ -646,8 +649,17 @@ el argumento 'report'. Por favor, intentelo nuevamente.""")
         Returns:
             str: Texto de la descripción generada.
         """
+        # Si se paso una ruta, guardarla
+        if isinstance(catalog, (str, unicode)):
+            catalog_path_or_url = catalog
+        else:
+            catalog_path_or_url = None
+
         catalog = readers.read_catalog(catalog)
         validation = self.validate_catalog(catalog)
+        # Solo necesito indicadores para un catalogo
+        indicators = self.generate_catalogs_indicators(
+            catalog, CENTRAL_CATALOG)[0][0]
 
         readme_template = """
 # Catálogo: {title}
@@ -656,6 +668,7 @@ el argumento 'report'. Por favor, intentelo nuevamente.""")
 
 - **Autor**: {publisher_name}
 - **Correo Electrónico**: {publisher_mbox}
+- **Ruta del catálogo**: {catalog_path_or_url}
 - **Nombre del catálogo**: {title}
 - **Descripción**:
 
@@ -663,14 +676,28 @@ el argumento 'report'. Por favor, intentelo nuevamente.""")
 
 ## Estado de los metadatos y cantidad de recursos
 
-Estado metadatos globales | Estado metadatos catálogo | # de Datasets | # de Distribuciones
---------------------------|---------------------------|---------------|--------------------
-{global_status} | {catalog_status} | {no_of_datasets} | {no_of_distributions}
+- **Estado metadatos globales**: {global_status}
+- **Estado metadatos catálogo**: {catalog_status}
+- **Cantidad Total de Datasets**: {no_of_datasets}
+- **Cantidad Total de Distribuciones**: {no_of_distributions}
+
+- **Cantidad de Datasets Federados**: {federated_datasets}
+- **Cantidad de Datasets NO Federados**: {not_federated_datasets}
+- **Porcentaje de Datasets NO Federados"": {not_federated_datasets_pct}%
+
+## Datasets no federados:
+
+{not_federated_datasets_list}
 
 ## Datasets incluidos
 
 Por favor, consulte el informe [`datasets.csv`](datasets.csv).
 """
+
+        not_federated_datasets_list = "\n".join([
+            "- [{}]({})".format(dataset[0], dataset[1])
+            for dataset in indicators["datasets_no_federados"]
+        ])
 
         content = {
             "title": catalog.get("title"),
@@ -678,12 +705,18 @@ Por favor, consulte el informe [`datasets.csv`](datasets.csv).
                 catalog, ["publisher", "name"]),
             "publisher_mbox": helpers.traverse_dict(
                 catalog, ["publisher", "mbox"]),
+            "catalog_path_or_url": catalog_path_or_url,
             "description": catalog.get("description"),
             "global_status": validation["status"],
             "catalog_status": validation["error"]["catalog"]["status"],
             "no_of_datasets": len(catalog["dataset"]),
             "no_of_distributions": sum([len(dataset["distribution"]) for
-                                        dataset in catalog["dataset"]])
+                                        dataset in catalog["dataset"]]),
+            "federated_datasets": indicators["datasets_federados_cant"],
+            "not_federated_datasets": indicators["datasets_no_federados_cant"],
+            "not_federated_datasets_pct": (
+                100.0 - indicators["datasets_federados_pct"]),
+            "not_federated_datasets_list": not_federated_datasets_list
         }
 
         catalog_readme = readme_template.format(**content)
@@ -1080,7 +1113,6 @@ El reporte no contiene la clave obligatoria {}. Pruebe con otro archivo.
             days_diff = float((datetime.now() - date).days)
             interval = helpers.parse_repeating_time_interval(periodicity) * \
                 (1 + tolerance)
-
 
             if days_diff < interval:
                 actualizados += 1

--- a/tests/results/catalog_readme.md
+++ b/tests/results/catalog_readme.md
@@ -5,6 +5,7 @@
 
 - **Autor**: Ministerio de Modernización
 - **Correo Electrónico**: datos@modernizacion.gob.ar
+- **Ruta del catálogo**: tests/samples/several_datasets_for_harvest.json
 - **Nombre del catálogo**: Cosechando Datos Argentina
 - **Descripción**:
 
@@ -12,9 +13,20 @@
 
 ## Estado de los metadatos y cantidad de recursos
 
-Estado metadatos globales | Estado metadatos catálogo | # de Datasets | # de Distribuciones
---------------------------|---------------------------|---------------|--------------------
-ERROR | OK | 3 | 6
+- **Estado metadatos globales**: ERROR
+- **Estado metadatos catálogo**: OK
+- **Cantidad Total de Datasets**: 3
+- **Cantidad Total de Distribuciones**: 6
+
+- **Cantidad de Datasets Federados**: 0
+- **Cantidad de Datasets NO Federados**: 3
+- **Porcentaje de Datasets NO Federados**: 100.0%
+
+## Datasets no federados:
+
+- [Sistema de contrataciones electrónicas UNO](None)
+- [Sistema de contrataciones electrónicas DOS](None)
+- [Sistema de contrataciones electrónicas TRES](None)
 
 ## Datasets incluidos
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -886,6 +886,7 @@ revíselo manualmente""".format(actual_filename)
         expected = {
             'datasets_federados_cant': 3,
             'datasets_no_federados_cant': 0,
+            'datasets_no_federados': [],
             'datasets_federados_pct': 100
         }
 
@@ -901,6 +902,10 @@ revíselo manualmente""".format(actual_filename)
         expected = {
             'datasets_federados_cant': 0,
             'datasets_no_federados_cant': 3,
+            'datasets_no_federados': [
+                ('Sistema de contrataciones electrónicas UNO', None),
+                ('Sistema de contrataciones electrónicas DOS', None),
+                ('Sistema de contrataciones electrónicas TRES', None)],
             'datasets_federados_pct': 0
         }
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -944,43 +944,6 @@ revíselo manualmente""".format(actual_filename)
         for k,v in expected.items():
             self.assertEqual(network_indicators[k], v)
 
-    def test_add_dicts(self):
-        # Testea la función auxiliar para sumar campos de dicts recursivamente
-        from pydatajson.helpers import add_dicts
-
-        dict = {
-            "distribuciones_formatos_cant": {
-                "SHP": 207,
-                "ZIP": 122,
-                "JPEG": 26,
-                "PDF": 235,
-                "CSV": 375,
-                "XLS": 25
-            }
-        }
-        other = {
-            "distribuciones_formatos_cant": {
-                "RDF": 1,
-                "CSV": 124,
-                "JSON": 5
-            }
-        }
-
-        expected = {
-            "distribuciones_formatos_cant": {
-                "SHP": 207,
-                "ZIP": 122,
-                "JPEG": 26,
-                "PDF": 235,
-                "CSV": 499,
-                "XLS": 25,
-                "RDF": 1,
-                "JSON": 5
-            }
-        }
-        result = add_dicts(dict, other)
-        self.assertDictEqual(result, expected)
-
     def test_indicators_invalid_periodicity(self):
         catalog = os.path.join(self.SAMPLES_DIR,
                                "malformed_accrualperiodicity.json")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -146,6 +146,55 @@ class HelpersTestCase(unittest.TestCase):
 
         self.assertFalse(result)
 
+    def test_add_dicts(self):
+        # Testea la función auxiliar para sumar campos de dicts recursivamente
+        from pydatajson.helpers import add_dicts
+
+        one_dict = {
+            "distribuciones_formatos_cant": {
+                "SHP": 207,
+                "ZIP": 122,
+                "JPEG": 26,
+                "PDF": 235,
+                "CSV": 375,
+                "XLS": 25
+            },
+            "una_lista": ["a", 1, True],
+            "dict_anidado": {
+                "valor": 12
+            }
+        }
+        other_dict = {
+            "distribuciones_formatos_cant": {
+                "RDF": 1,
+                "CSV": 124,
+                "JSON": 5
+            },
+            "una_lista": ["b", 2, False],
+            "dict_anidado": {
+                "valor": 24
+            }
+        }
+
+        expected = {
+            "distribuciones_formatos_cant": {
+                "SHP": 207,
+                "ZIP": 122,
+                "JPEG": 26,
+                "PDF": 235,
+                "CSV": 499,
+                "XLS": 25,
+                "RDF": 1,
+                "JSON": 5
+            },
+            "una_lista": ["b", 2, False, "a", 1, True],
+            "dict_anidado": {
+                "valor": 36
+            }
+        }
+        result = pydatajson.helpers.add_dicts(one_dict, other_dict)
+        self.assertDictEqual(result, expected)
+
 
 if __name__ == '__main__':
     nose.run(defaultTest=__name__)


### PR DESCRIPTION
Cambios:
- Modifiqué el template de CATALOG README
- Agregué el indicador "datasets_no_federados" a generate_catalogs_indicators
- Agregué una variable global al módulo `core`: CENTRAL_CATALOG, para saber contra qué comparar para obtener estadísticas de federación.

Esta última decisión, la de la variable global, es la más polémica supongo. Tampoco es la muerte de nadie.