### PR TITLE
Métodos auxiliares usados para caluclar indicadores del PAD

### DIFF
--- a/pydatajson/__init__.py
+++ b/pydatajson/__init__.py
@@ -5,6 +5,7 @@ Conjunto de herramientas para validar y manipular la información presente en
 el archivo `data.json` de un Portal de Datos
 """
 from .core import DataJson
+from .helpers import parse_repeating_time_interval
 
 __author__ = """Datos Argentina"""
 __email__ = 'datos@modernizacion.gob.ar'

--- a/pydatajson/core.py
+++ b/pydatajson/core.py
@@ -1244,6 +1244,28 @@ El reporte no contiene la clave obligatoria {}. Pruebe con otro archivo.
 
         return key_count
 
+    def dataset_is_updated(self, catalog, dataset):
+        catalog = readers.read_catalog(catalog)
+
+        for catalog_dataset in catalog.get('dataset', []):
+            if catalog_dataset.get('title') == dataset:
+                periodicity = catalog_dataset.get('accrualPeriodicity')
+                if not periodicity:
+                    return False
+
+                if periodicity == 'eventual':
+                    return True
+
+                date = self._parse_date_string(catalog_dataset['issued'])
+                days_diff = float((datetime.now() - date).days)
+                interval = helpers.parse_repeating_time_interval(periodicity)
+
+                if days_diff < interval:
+                    return True
+                return False
+
+        return False
+
 
 def main():
     """Permite ejecutar el módulo por línea de comandos.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -922,6 +922,8 @@ revíselo manualmente""".format(actual_filename)
         ])
 
         # Esperado: suma de los indicadores individuales
+        # No se testean los indicadores de actualización porque las fechas no
+        # se mantienen actualizadas
         expected = {
             'catalogos_cant': 2,
             'datasets_cant': 4,
@@ -936,9 +938,6 @@ revíselo manualmente""".format(actual_filename)
             },
             'campos_optativos_pct': 21.95,
             'campos_recomendados_pct': 44.72,
-            'datasets_actualizados_cant': 2,
-            'datasets_desactualizados_cant': 2,
-            'datasets_actualizados_pct': 50
         }
 
         for k,v in expected.items():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1011,6 +1011,16 @@ revíselo manualmente""".format(actual_filename)
         for k, v in expected.items():
             self.assertEqual(indicators[k], v, k)
 
+    def test_dataset_is_updated(self):
+        catalog = os.path.join(self.SAMPLES_DIR, "catalogo_justicia.json")
+
+        # Datasset con periodicity mensual vencida
+        dataset = "Base de datos legislativos Infoleg"
+        self.assertFalse(self.dj.dataset_is_updated(catalog, dataset))
+
+        # Dataset con periodicity eventual, siempre True
+        dataset = "Declaración Jurada Patrimonial Integral de carácter público"
+        self.assertTrue(self.dj.dataset_is_updated(catalog, dataset))
 
 if __name__ == '__main__':
     nose.run(defaultTest=__name__)


### PR DESCRIPTION
- Agrego un método `dataset_is_updated` en `DataJson` para verificar si un dataset dentro del catálogo se encuentra actualizado.
- Expongo públicamente el método `parse_repeating_time_interval` de `helpers`.