### PR TITLE
Arreglo indicadores de red nulos cuando un catálogo es inválido

### DIFF
--- a/pydatajson/helpers.py
+++ b/pydatajson/helpers.py
@@ -166,10 +166,16 @@ def add_dicts(one_dict, other_dict):
     """
     result = other_dict.copy()
     for k, v in one_dict.items():
+        if v is None:
+            v = 0
+
         if isinstance(v, dict):
             result[k] = add_dicts(v, other_dict.get(k, {}))
         else:
-            result[k] = result.get(k, 0) + v
+            other_value = result.get(k, 0)
+            if other_value is None:
+                other_value = 0
+            result[k] = other_value + v
 
     return result
 

--- a/tests/samples/invalid_catalog_empty.json
+++ b/tests/samples/invalid_catalog_empty.json
@@ -1,0 +1,11 @@
+{
+    "publisher": {
+        "mbox": "",
+        "name": ""
+    },
+    "description": "Describí el portal. Explicá de qué se trata tu catálogo de datos. Por favor, hacelo en no más de tres líneas.",
+    "superThemeTaxonomy": "http://datos.gob.ar/superThemeTaxonomy.json",
+    "title": "Ministerio de Desarrollos Social",
+    "dataset": [],
+    "themeTaxonomy": []
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1086,6 +1086,15 @@ revíselo manualmente""".format(actual_filename)
     def test_parse_date_string(self):
         self.assertEqual(self.dj._parse_date_string(""), None)
 
+    def test_date_network_indicators_empty_catalog(self):
+        catalog = os.path.join(self.SAMPLES_DIR, "invalid_catalog_empty.json")
+        indics, network_indics = self.dj.generate_catalogs_indicators(
+            [catalog,
+             catalog]
+        )
+
+        for k, v in network_indics.items():
+            self.assertTrue(v is not None)
 
 if __name__ == '__main__':
     nose.run(defaultTest=__name__)


### PR DESCRIPTION
- Modifica el método `helpers.add_dicts` para que reemplaze los valores de tipo `None` por un valor nulo
- Agrega un caso de prueba que verifique que ante un catálogo inválido no se levante una excepción al calcularse los indicadores de red