### PR TITLE
85 validar download url en recursos

### DIFF
--- a/pydatajson/custom_exceptions.py
+++ b/pydatajson/custom_exceptions.py
@@ -61,6 +61,21 @@ class ThemeLabelRepeated(BaseValidationError):
             validator, message, validator_value, path)
 
 
+class DownloadURLRepetitionError(BaseValidationError):
+
+    def __init__(self, repeated_urls):
+
+        # TODO: construcción del error
+        validator = "repeatedValue"
+        message = "downloadURL's {} estan repetidas en mas de un `distribution`".format(
+            repeated_urls)
+        validator_value = "Chequea downloadURL's duplicados en las distribuciones"
+        path = ["catalog", "dataset", "distribution"]
+
+        super(DownloadURLRepetitionError, self).__init__(
+            validator, message, validator_value, path)
+
+
 class BaseUnexpectedValue(ValueError):
 
     """El id de una entidad está repetido en el catálogo."""

--- a/pydatajson/custom_exceptions.py
+++ b/pydatajson/custom_exceptions.py
@@ -67,10 +67,10 @@ class DownloadURLRepetitionError(BaseValidationError):
 
         # TODO: construcción del error
         validator = "repeatedValue"
-        message = "downloadURL's {} estan repetidas en mas de un `distribution`".format(
+        message = "DownloadURL's {} estan repetidas en mas de un `distribution`".format(
             repeated_urls)
         validator_value = "Chequea downloadURL's duplicados en las distribuciones"
-        path = ["catalog", "dataset", "distribution"]
+        path = ["catalog", "dataset"]
 
         super(DownloadURLRepetitionError, self).__init__(
             validator, message, validator_value, path)

--- a/pydatajson/validation.py
+++ b/pydatajson/validation.py
@@ -262,18 +262,14 @@ def iter_custom_errors(catalog):
     validaciones complicadas o imposibles de especificar usando jsonschema.
     """
 
-    # chequea que no se repiten los ids de la taxonomía específica
     try:
+        # chequea que no se repiten los ids de la taxonomía específica
         if "themeTaxonomy" in catalog:
             theme_ids = [theme["id"] for theme in catalog["themeTaxonomy"]]
             dups = _find_dups(theme_ids)
             if len(dups) > 0:
                 yield ce.ThemeIdRepeated(dups)
-    except Exception as e:
-        print(e)
-
-    # chequea que la extensión de fileName y format sean consistentes
-    try:
+        # chequea que la extensión de fileName y format sean consistentes
         for dataset in catalog["dataset"]:
             for distribution in dataset:
                 if "fileName" in distribution and "format" in distribution:
@@ -285,6 +281,15 @@ def iter_custom_errors(catalog):
                         yield ce.FileNameExtensionError(
                             distribution["identifier"], format_extension,
                             fileName_extension)
+        # chequea que no haya duplicados en los downloadURL de las distribuciones
+        urls = []
+        for dataset in catalog["dataset"]:
+            urls += [distribution['downloadURL'] for distribution in dataset['distribution']
+                     if distribution.get('downloadURL')]
+        dups = _find_dups(urls)
+        if len(dups) > 0:
+            yield ce.DownloadURLRepetitionError(dups)
+
     except Exception as e:
         print(e)
 

--- a/tests/samples/repeated_downloadURL.json
+++ b/tests/samples/repeated_downloadURL.json
@@ -1,0 +1,175 @@
+{
+    "title": "Datos Argentina",
+    "description": "Portal de Datos Abiertos del Gobierno de la República Argentina",
+    "publisher": {
+        "name": "Ministerio de Modernización",
+        "mbox": "datos@modernizacion.gob.ar"
+    },
+    "issued": "2016-04-14T19:48:05.433640-03:00",
+    "modified": "2016-04-19T19:48:05.433640-03:00",
+    "language": [
+        "spa"
+    ],
+    "superThemeTaxonomy": "http://datos.gob.ar/superThemeTaxonomy.json",
+    "themeTaxonomy": [
+        {
+            "id": "convocatorias",
+            "label": "Convocatorias",
+            "description": "Datasets sobre licitaciones en estado de convocatoria."
+        },
+        {
+            "id": "compras",
+            "label": "Compras",
+            "description": "Datasets sobre compras realizadas."
+        },
+        {
+            "id": "contrataciones",
+            "label": "Contrataciones",
+            "description": "Datasets sobre contrataciones."
+        },
+        {
+            "id": "adjudicaciones",
+            "label": "Adjudicaciones",
+            "description": "Datasets sobre licitaciones adjudicadas."
+        },
+        {
+            "id": "normativa",
+            "label": "Normativa",
+            "description": "Datasets sobre normativa para compras y contrataciones."
+        },
+        {
+            "id": "proveedores",
+            "label": "Proveedores",
+            "description": "Datasets sobre proveedores del Estado."
+        }
+    ],
+    "license": "Open Data Commons Open Database License 1.0",
+    "homepage": "http://datos.gob.ar",
+    "rights": "Derechos especificados en la licencia.",
+    "spatial": "ARG",
+    "dataset": [
+        {
+            "title": "Sistema de contrataciones electrónicas",
+            "description": "Datos correspondientes al Sistema de Contrataciones Electrónicas (Argentina Compra)",
+            "publisher": {
+                "name": "Ministerio de Modernización. Secretaría de Modernización Administrativa. Oficina Nacional de Contrataciones",
+                "mbox": "onc@modernizacion.gob.ar"
+            },
+            "contactPoint": {
+                "fn": "Ministerio de Modernización. Secretaría de Modernización Administrativa. Oficina Nacional de Contrataciones. Dirección de Compras Electrónicas.",
+                "hasEmail": "onc-compraselectronicas@modernizacion.gob.ar"
+            },
+            "superTheme": [
+                "econ"
+            ],
+            "theme": [
+                "contrataciones",
+                "compras",
+                "convocatorias"
+            ],
+            "keyword": [
+                "bienes",
+                "compras",
+                "contrataciones"
+            ],
+            "accrualPeriodicity": "R/P1Y",
+            "issued": "2016-04-14T19:48:05.433640-03:00",
+            "modified": "2016-04-19T19:48:05.433640-03:00",
+            "identifier": "99db6631-d1c9-470b-a73e-c62daa32c420",
+            "language": [
+                "spa"
+            ],
+            "spatial": "ARG",
+            "temporal": "2015-01-01/2015-12-31",
+            "landingPage": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra",
+            "license": "Open Data Commons Open Database License 1.0",
+            "distribution": [
+                {
+                    "accessURL": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra/archivo/fa3603b3-0af7-43cc-9da9-90a512217d8a",
+                    "description": "Listado de las convocatorias abiertas durante el año 2015 en el sistema de contrataciones electrónicas",
+                    "format": "CSV",
+                    "mediaType": "text/csv",
+                    "downloadURL": "http://186.33.211.253/dataset/99db6631-d1c9-470b-a73e-c62daa32c420/resource/4b7447cb-31ff-4352-96c3-589d212e1cc9/download/convocatorias-abiertas-anio-2015.csv",
+                    "title": "Convocatorias abiertas durante el año 2015",
+                    "license": "Open Data Commons Open Database License 1.0",
+                    "byteSize": 5120,
+                    "issued": "2016-04-14T19:48:05.433640-03:00",
+                    "modified": "2016-04-19T19:48:05.433640-03:00",
+                    "rights": "Derechos especificados en la licencia.",
+                    "identifier": "1.1",
+                    "field": [
+                        {
+                            "title": "procedimiento_id",
+                            "type": "integer",
+                            "description": "Identificador único del procedimiento de contratación",
+                            "id": "proc12"
+                        },
+                        {
+                            "title": "organismo_unidad_operativa_contrataciones_id",
+                            "type": "integer",
+                            "description": "Identificador único del organismo que realiza la convocatoria. Organismo de máximo nivel jerárquico al que pertenece la unidad operativa de contrataciones."
+                        },
+                        {
+                            "title": "unidad_operativa_contrataciones_id",
+                            "type": "integer",
+                            "description": "Identificador único de la unidad operativa de contrataciones"
+                        },
+                        {
+                            "title": "organismo_unidad_operativa_contrataciones_desc",
+                            "type": "string",
+                            "description": "Organismo que realiza la convocatoria. Organismo de máximo nivel jerárquico al que pertenece la unidad operativa de contrataciones."
+                        },
+                        {
+                            "title": "unidad_operativa_contrataciones_desc",
+                            "type": "string",
+                            "description": "Unidad operativa de contrataciones."
+                        },
+                        {
+                            "title": "tipo_procedimiento_contratacion",
+                            "type": "string",
+                            "description": "Tipo de procedimiento al que se adecua la contratación."
+                        },
+                        {
+                            "title": "ejercicio_procedimiento_anio",
+                            "type": "date",
+                            "description": "Año en el que se inició el proceso de la convocatoria."
+                        },
+                        {
+                            "title": "fecha_publicacion_convocatoria",
+                            "type": "date",
+                            "description": "Fecha de publicación de la convocatoria en formato AAAA-MM-DD, ISO 8601."
+                        },
+                        {
+                            "title": "modalidad_convocatoria",
+                            "type": "string",
+                            "description": "Modalidad bajo la cual se realiza la convocatoria."
+                        },
+                        {
+                            "title": "clase_convocatoria",
+                            "type": "string",
+                            "description": "Clase de la convocatoria."
+                        },
+                        {
+                            "title": "objeto_convocatoria",
+                            "type": "string",
+                            "description": "Objeto/objetivo de la convocatoria"
+                        }
+                    ]
+                },
+                {
+                    "accessURL": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra/archivo/fa3603b3-0af7-43cc-9da9-90a512217d8a",
+                    "description": "Listado de las convocatorias abiertas durante el año 2015 en el sistema de contrataciones electrónicas",
+                    "format": "PDF",
+                    "mediaType": "application/pdf",
+                    "downloadURL": "http://186.33.211.253/dataset/99db6631-d1c9-470b-a73e-c62daa32c420/resource/4b7447cb-31ff-4352-96c3-589d212e1cc9/download/convocatorias-abiertas-anio-2015.csv",
+                    "title": "Convocatorias abiertas durante el año 2015",
+                    "license": "Open Data Commons Open Database License 1.0",
+                    "byteSize": 5120,
+                    "issued": "2016-04-14T19:48:05.433640-03:00",
+                    "modified": "2016-04-19T19:48:05.433640-03:00",
+                    "rights": "Derechos especificados en la licencia."
+                }
+            ]
+        }
+    ]
+}

--- a/tests/support/factories/catalog_errors.py
+++ b/tests/support/factories/catalog_errors.py
@@ -279,3 +279,19 @@ def missing_dataset():
         ],
         "dataset": None,
     })
+
+
+def repeated_downloadURL():
+    return catalog_error({
+        "instance": None,
+        "validator": "repeatedValue",
+        "path": [
+            "catalog",
+            "dataset"
+        ],
+        "message": "DownloadURL's [%s] estan repetidas en mas de un `distribution`" % jsonschema_str(
+            'http://186.33.211.253/dataset/99db6631-d1c9-470b-a73e-c62daa32c420/resource/4b7447cb-31ff-4352-96c3-589d212e1cc9/download/convocatorias-abiertas-anio-2015.csv'),
+        "error_code": 2,
+        "validator_value": "Chequea downloadURL's duplicados en las distribuciones"
+    })
+

--- a/tests/support/factories/core_files.py
+++ b/tests/support/factories/core_files.py
@@ -7,7 +7,8 @@ from .catalog_errors import missing_catalog_title, \
     missing_catalog_description, \
     missing_catalog_dataset, invalid_catalog_publisher_type, invalid_publisher_mbox_format, \
     null_catalog_publisher, empty_mandatory_string, malformed_date, malformed_datetime, \
-    malformed_datetime2, malformed_email, malformed_uri, invalid_theme_taxonomy, missing_dataset
+    malformed_datetime2, malformed_email, malformed_uri, invalid_theme_taxonomy, missing_dataset, \
+    repeated_downloadURL
 from .dataset_errors import missing_dataset_title, \
     missing_dataset_description, \
     malformed_accrualperiodicity, malformed_temporal, malformed_temporal2, too_long_field_title
@@ -92,6 +93,8 @@ TEST_FROM_GENERATED_RESULT = {
 
     'invalid_catalog_publisher_type': invalid_catalog_publisher_type(),
     'invalid_publisher_mbox_format': invalid_publisher_mbox_format(),
+
+    'repeated_downloadURL': repeated_downloadURL(),
 }
 
 TEST_FILE_RESPONSES = {}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -79,7 +79,7 @@ class TestDataJsonTestCase(object):
         else:
             raise Exception("LA RESPUESTA {} TIENE UN status INVALIDO".format(
                 case_filename))
-
+qe
         assert_dict_equal(expected_dict, response_dict)
 
     # Tests de CAMPOS REQUERIDOS

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -79,7 +79,7 @@ class TestDataJsonTestCase(object):
         else:
             raise Exception("LA RESPUESTA {} TIENE UN status INVALIDO".format(
                 case_filename))
-qe
+
         assert_dict_equal(expected_dict, response_dict)
 
     # Tests de CAMPOS REQUERIDOS


### PR DESCRIPTION
Closes #85 
Valida que los recursos tengan `downloadURL` única. Crea una nueva custom exception y la levanta si este campo está duplicado