### PR TITLE
93 validar formatos y filenames

### DIFF
--- a/pydatajson/custom_exceptions.py
+++ b/pydatajson/custom_exceptions.py
@@ -76,6 +76,20 @@ class DownloadURLRepetitionError(BaseValidationError):
             validator, message, validator_value, path)
 
 
+class FileNameExtensionError(BaseValidationError):
+
+    def __init__(self, dataset_idx, distribution_idx, distribution):
+
+        validator = 'mismatchedValue'
+        message = "distribution '{}' tiene distintas extensiones: format ('{}') y fileName ('{}')".format(
+            distribution['identifier'], distribution['format'], distribution['fileName'].split('.')[-1])
+        validator_value = 'Chequea format y la extension del fileName'
+        path = ['dataset', dataset_idx, 'distribution', distribution_idx]
+
+        super(FileNameExtensionError, self).__init__(
+            validator, message, validator_value, path)
+
+
 class BaseUnexpectedValue(ValueError):
 
     """El id de una entidad está repetido en el catálogo."""
@@ -311,12 +325,3 @@ class ThemeTaxonomyNonExistentError(Exception):
     def __init__(self, dataset_id):
         msg = "Catalogo no tiene themeTaxonomy"
         super(ThemeTaxonomyNonExistentError, self).__init__(msg)
-
-
-class FileNameExtensionError(Exception):
-
-    def __init__(self, distribution_id, format_extension, fileName_extension):
-        tmpl = "distribution '{}' tiene distintas extensiones: format ('{}') y fileName ('{}')"
-        msg = tmpl.format(distribution_id, format_extension,
-                          fileName_extension)
-        super(FileNameExtensionError, self).__init__(msg)

--- a/pydatajson/validation.py
+++ b/pydatajson/validation.py
@@ -10,6 +10,7 @@ from __future__ import unicode_literals, print_function, with_statement, absolut
 
 import os
 import platform
+import mimetypes
 from collections import Counter
 
 import jsonschema
@@ -270,17 +271,10 @@ def iter_custom_errors(catalog):
             if len(dups) > 0:
                 yield ce.ThemeIdRepeated(dups)
         # chequea que la extensión de fileName y format sean consistentes
-        for dataset in catalog["dataset"]:
-            for distribution in dataset:
-                if "fileName" in distribution and "format" in distribution:
-                    format_extension = distribution[
-                        "format"].split("/")[-1].lower()
-                    fileName_extension = distribution[
-                        "extension"].split(".")[-1].lower()
-                    if format_extension != fileName_extension:
-                        yield ce.FileNameExtensionError(
-                            distribution["identifier"], format_extension,
-                            fileName_extension)
+        for dataset_idx, dataset in enumerate(catalog["dataset"]):
+            for distribution_idx, distribution in enumerate(dataset["distribution"]):
+                if not format_matches_extension(distribution):
+                    yield ce.FileNameExtensionError(dataset_idx, distribution_idx, distribution)
         # chequea que no haya duplicados en los downloadURL de las distribuciones
         urls = []
         for dataset in catalog["dataset"]:
@@ -381,3 +375,17 @@ def _catalog_validation_to_list(response):
             rows_dataset.append(validation_result)
 
     return {"catalog": rows_catalog, "dataset": rows_dataset}
+
+
+def format_matches_extension(distribution):
+    if "fileName" in distribution and "format" in distribution:
+        fileName_extension = distribution["fileName"].split(".")[-1].lower()
+        if "/" in distribution['format']:
+            fileName_extension = '.' + fileName_extension
+            possible_format_extensions = mimetypes.guess_all_extensions(distribution['format'])
+            if fileName_extension not in possible_format_extensions:
+                return False
+        else:
+            if fileName_extension != distribution['format'].lower():
+                return False
+    return True

--- a/tests/results/mismatched_fileName_and_format.json
+++ b/tests/results/mismatched_fileName_and_format.json
@@ -29,10 +29,24 @@
                 "title": "Sistema de contrataciones electr\u00f3nicas"
             }, 
             {
-                "status": "OK", 
+                "status": "ERROR", 
                 "identifier": "99db6631-d1c9-470b-a73e-c62daa32c420", 
                 "list_index": 1, 
-                "errors": [], 
+                "errors": [
+                    {
+                        "instance": null, 
+                        "validator": "mismatchedValue", 
+                        "path": [
+                            "dataset", 
+                            1, 
+                            "distribution", 
+                            1
+                        ], 
+                        "message": "distribution 'd_7d4d816f-3a40-476e-ab71-d48a3f0eb3c9' tiene distintas extensiones: format ('application/vnd.ms-excel') y fileName ('xlsx')", 
+                        "error_code": 2, 
+                        "validator_value": "Chequea format y la extension del fileName"
+                    }
+                ], 
                 "title": "Sistema de contrataciones electr\u00f3nicas (sin datos)"
             }
         ]

--- a/tests/results/mismatched_fileName_and_format.json
+++ b/tests/results/mismatched_fileName_and_format.json
@@ -1,0 +1,40 @@
+{
+    "status": "ERROR", 
+    "error": {
+        "catalog": {
+            "status": "OK", 
+            "errors": [], 
+            "title": "Datos Argentina"
+        }, 
+        "dataset": [
+            {
+                "status": "ERROR", 
+                "identifier": "99db6631-d1c9-470b-a73e-c62daa32c777", 
+                "list_index": 0, 
+                "errors": [
+                    {
+                        "instance": null, 
+                        "validator": "mismatchedValue", 
+                        "path": [
+                            "dataset", 
+                            0, 
+                            "distribution", 
+                            0
+                        ], 
+                        "message": "distribution '1.1' tiene distintas extensiones: format ('PDF') y fileName ('csv')", 
+                        "error_code": 2, 
+                        "validator_value": "Chequea format y la extension del fileName"
+                    }
+                ], 
+                "title": "Sistema de contrataciones electr\u00f3nicas"
+            }, 
+            {
+                "status": "OK", 
+                "identifier": "99db6631-d1c9-470b-a73e-c62daa32c420", 
+                "list_index": 1, 
+                "errors": [], 
+                "title": "Sistema de contrataciones electr\u00f3nicas (sin datos)"
+            }
+        ]
+    }
+}

--- a/tests/samples/mismatched_fileName_and_format.json
+++ b/tests/samples/mismatched_fileName_and_format.json
@@ -177,6 +177,22 @@
                     "downloadURL": "http://186.33.211.253/dataset/99db6631-d1c9-470b-a73e-c62daa32c420/resource/4b7447cb-31ff-4352-96c3-589d212e1cc9/download/convocatorias-abiertas-anio-2015.xls",
                     "issued": "2016-04-14T19:48:05.433640-03:00",
                     "fileName": "convocatoriasabiertasduranteelao.xls"
+                },
+                {
+                    "accessURL": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra/archivo/fa3603b3-0af7-43cc-9da9-90a512217d8b",
+                    "identifier": "d_7d4d816f-3a40-476e-ab71-d48a3f0eb3c9",
+                    "description": "Listado de las convocatorias abiertas durante el año 2015 en el sistema de contrataciones electrónicas",
+                    "license": "Open Data Commons Open Database License 1.0",
+                    "title": "Convocatorias abiertas durante el año 2015",
+                    "dataset_identifier": "99db6631-d1c9-470b-a73e-c62daa32c420",
+                    "byteSize": 5120,
+                    "format": "application/vnd.ms-excel",
+                    "rights": "Derechos especificados en la licencia.",
+                    "mediaType": "application/vnd.ms-excel",
+                    "modified": "2016-04-19T19:48:05.433640-03:00",
+                    "downloadURL": "http://186.33.211.253/dataset/99db6631-d1c9-470b-a73e-c62daa32c420/resource/4b7447cb-31ff-4352-96c3-589d212e1cc9/download/convocatorias-abiertas-anio-2015.xlsx",
+                    "issued": "2016-04-14T19:48:05.433640-03:00",
+                    "fileName": "convocatoriasabiertasduranteelao.xlsx"
                 }
             ],
             "source": "Ministerio de modernizacion"

--- a/tests/samples/mismatched_fileName_and_format.json
+++ b/tests/samples/mismatched_fileName_and_format.json
@@ -1,0 +1,222 @@
+{
+    "publisher": {
+        "mbox": "datos@modernizacion.gob.ar",
+        "name": "Ministerio de Modernización"
+    },
+    "license": "Open Data Commons Open Database License 1.0",
+    "description": "Portal de Datos Abiertos del Gobierno de la República Argentina",
+    "language": [
+        "spa"
+    ],
+    "title": "Datos Argentina",
+    "issued": "2016-04-14T19:48:05.433640-03:00",
+    "rights": "Derechos especificados en la licencia.",
+    "modified": "2016-04-19T19:48:05.433640-03:00",
+    "dataset": [
+        {
+            "publisher": {
+                "mbox": "onc@modernizacion.gob.ar",
+                "name": "Ministerio de Modernización. Secretaría de Modernización Administrativa. Oficina Nacional de Contrataciones"
+            },
+            "license": "Open Data Commons Open Database License 1.0",
+            "description": "Datos correspondientes al Sistema de Contrataciones Electrónicas (Argentina Compra)",
+            "superTheme": [
+                "econ"
+            ],
+            "title": "Sistema de contrataciones electrónicas",
+            "issued": "2016-04-14T19:48:05.433640-03:00",
+            "temporal": "2015-01-01/2015-12-31",
+            "modified": "2016-04-19T19:48:05.433640-03:00",
+            "language": [
+                "spa"
+            ],
+            "theme": [
+                "contrataciones",
+                "compras",
+                "convocatorias"
+            ],
+            "keyword": [
+                "bienes",
+                "compras",
+                "contrataciones"
+            ],
+            "accrualPeriodicity": "R/P1Y",
+            "spatial": "ARG",
+            "identifier": "99db6631-d1c9-470b-a73e-c62daa32c777",
+            "contactPoint": {
+                "hasEmail": "onc-compraselectronicas@modernizacion.gob.ar",
+                "fn": "Ministerio de Modernización. Secretaría de Modernización Administrativa. Oficina Nacional de Contrataciones. Dirección de Compras Electrónicas."
+            },
+            "landingPage": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra",
+            "distribution": [
+                {
+                    "accessURL": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra/archivo/fa3603b3-0af7-43cc-9da9-90a512217d8a",
+                    "identifier": "1.1",
+                    "description": "Listado de las convocatorias abiertas durante el año 2015 en el sistema de contrataciones electrónicas",
+                    "license": "Open Data Commons Open Database License 1.0",
+                    "title": "Convocatorias abiertas durante el año 2015",
+                    "dataset_identifier": "99db6631-d1c9-470b-a73e-c62daa32c777",
+                    "byteSize": 5120,
+                    "format": "PDF",
+                    "rights": "Derechos especificados en la licencia.",
+                    "mediaType": "text/csv",
+                    "modified": "2016-04-19T19:48:05.433640-03:00",
+                    "downloadURL": "http://186.33.211.253/dataset/99db6631-d1c9-470b-a73e-c62daa32c420/resource/4b7447cb-31ff-4352-96c3-589d212e1cc9/download/convocatorias-abiertas-anio-2015.csv",
+                    "field": [
+                        {
+                            "title": "procedimiento_id",
+                            "type": "integer",
+                            "id": "proc12",
+                            "description": "Identificador único del procedimiento de contratación"
+                        },
+                        {
+                            "type": "integer",
+                            "description": "Identificador único del organismo que realiza la convocatoria. Organismo de máximo nivel jerárquico al que pertenece la unidad operativa de contrataciones.",
+                            "title": "organismo_unidad_operativa_contrataciones_id"
+                        },
+                        {
+                            "type": "integer",
+                            "description": "Identificador único de la unidad operativa de contrataciones",
+                            "title": "unidad_operativa_contrataciones_id"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Organismo que realiza la convocatoria. Organismo de máximo nivel jerárquico al que pertenece la unidad operativa de contrataciones.",
+                            "title": "organismo_unidad_operativa_contrataciones_desc"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Unidad operativa de contrataciones.",
+                            "title": "unidad_operativa_contrataciones_desc"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Tipo de procedimiento al que se adecua la contratación.",
+                            "title": "tipo_procedimiento_contratacion"
+                        },
+                        {
+                            "type": "date",
+                            "description": "Año en el que se inició el proceso de la convocatoria.",
+                            "title": "ejercicio_procedimiento_anio"
+                        },
+                        {
+                            "type": "date",
+                            "description": "Fecha de publicación de la convocatoria en formato AAAA-MM-DD, ISO 8601.",
+                            "title": "fecha_publicacion_convocatoria"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Modalidad bajo la cual se realiza la convocatoria.",
+                            "title": "modalidad_convocatoria"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Clase de la convocatoria.",
+                            "title": "clase_convocatoria"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Objeto/objetivo de la convocatoria",
+                            "title": "objeto_convocatoria"
+                        }
+                    ],
+                    "issued": "2016-04-14T19:48:05.433640-03:00",
+                    "fileName": "convocatoriasabiertasduranteelao.csv"
+                }
+            ],
+            "source": "Ministerio de modernizacion"
+        },
+        {
+            "publisher": {
+                "mbox": "onc@modernizacion.gob.ar",
+                "name": "Ministerio de Modernización. Secretaría de Modernización Administrativa. Oficina Nacional de Contrataciones"
+            },
+            "license": "Open Data Commons Open Database License 1.0",
+            "description": "Datos correspondientes al Sistema de Contrataciones Electrónicas (Argentina Compra) (sin datos)",
+            "superTheme": [
+                "ECON"
+            ],
+            "title": "Sistema de contrataciones electrónicas (sin datos)",
+            "issued": "2016-04-14T19:48:05.433640-03:00",
+            "temporal": "2015-01-01/2015-12-31",
+            "modified": "2016-04-19T19:48:05.433640-03:00",
+            "language": [
+                "spa"
+            ],
+            "theme": [
+                "contrataciones",
+                "compras",
+                "convocatorias"
+            ],
+            "keyword": [
+                "bienes",
+                "compras",
+                "contrataciones"
+            ],
+            "accrualPeriodicity": "R/P1Y",
+            "spatial": "ARG",
+            "identifier": "99db6631-d1c9-470b-a73e-c62daa32c420",
+            "contactPoint": {
+                "hasEmail": "onc-compraselectronicas@modernizacion.gob.ar",
+                "fn": "Ministerio de Modernización. Secretaría de Modernización Administrativa. Oficina Nacional de Contrataciones. Dirección de Compras Electrónicas."
+            },
+            "landingPage": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra",
+            "distribution": [
+                {
+                    "accessURL": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra/archivo/fa3603b3-0af7-43cc-9da9-90a512217d8a",
+                    "identifier": "d_7d4d816f-3a40-476e-ab71-d48a3f0eb3c8",
+                    "description": "Listado de las convocatorias abiertas durante el año 2015 en el sistema de contrataciones electrónicas",
+                    "license": "Open Data Commons Open Database License 1.0",
+                    "title": "Convocatorias abiertas durante el año 2015",
+                    "dataset_identifier": "99db6631-d1c9-470b-a73e-c62daa32c420",
+                    "byteSize": 5120,
+                    "format": "application/vnd.ms-excel",
+                    "rights": "Derechos especificados en la licencia.",
+                    "mediaType": "application/vnd.ms-excel",
+                    "modified": "2016-04-19T19:48:05.433640-03:00",
+                    "downloadURL": "http://186.33.211.253/dataset/99db6631-d1c9-470b-a73e-c62daa32c420/resource/4b7447cb-31ff-4352-96c3-589d212e1cc9/download/convocatorias-abiertas-anio-2015.xls",
+                    "issued": "2016-04-14T19:48:05.433640-03:00",
+                    "fileName": "convocatoriasabiertasduranteelao.xls"
+                }
+            ],
+            "source": "Ministerio de modernizacion"
+        }
+    ],
+    "identifier": "7d4d816f-3a40-476e-ab71-d48a3f0eb3c8",
+    "version": "1.1",
+    "spatial": "ARG",
+    "superThemeTaxonomy": "http://datos.gob.ar/superThemeTaxonomy.json",
+    "themeTaxonomy": [
+        {
+            "label": "Convocatorias",
+            "description": "Datasets sobre licitaciones en estado de convocatoria.",
+            "id": "convocatorias"
+        },
+        {
+            "label": "Compras",
+            "description": "Datasets sobre compras realizadas.",
+            "id": "compras"
+        },
+        {
+            "label": "Contrataciones",
+            "description": "Datasets sobre contrataciones.",
+            "id": "contrataciones"
+        },
+        {
+            "label": "Adjudicaciones",
+            "description": "Datasets sobre licitaciones adjudicadas.",
+            "id": "adjudicaciones"
+        },
+        {
+            "label": "Normativa",
+            "description": "Datasets sobre normativa para compras y contrataciones.",
+            "id": "normativa"
+        },
+        {
+            "label": "Proveedores",
+            "description": "Datasets sobre proveedores del Estado.",
+            "id": "proveedores"
+        }
+    ],
+    "homepage": "http://datos.gob.ar"
+}

--- a/tests/support/factories/core_files.py
+++ b/tests/support/factories/core_files.py
@@ -61,7 +61,8 @@ TEST_FROM_RESULT_FILE = {
     'invalid_field_description_type': None,
     # La clave requerida catalog["description"] NO puede ser str vacía
     'empty_optional_string': None,
-
+    # El format y extension de fileName de las distribuciones deben coincidir si estan los campos presentes
+    'mismatched_fileName_and_format': None,
 }
 
 TEST_FROM_GENERATED_RESULT = {


### PR DESCRIPTION
Closes #93 

Agrego el test para la validación de extensión de fileName y format. Además cambio la validación para que tenga en cuenta formatos IANA donde el subtipo no es igual a la extensión. Por otro lado, arreglo FileNameExtensionError para que sea un error de validación a diferencia de una excepción.