### PR TITLE
Fixes y tests para función write_xlsx_catalog

### DIFF
--- a/pydatajson/writers.py
+++ b/pydatajson/writers.py
@@ -416,6 +416,8 @@ def _generate_field_table(catalog):
             field, "field", ["dataset", "distribution"])
         tab_field["dataset_title"] = catalog.get_dataset(
             tab_field["dataset_identifier"]).get("title")
+        tab_field["distribution_title"] = catalog.get_distribution(
+            tab_field["distribution_identifier"]).get("title")
         fields.append(tab_field)
 
         # agrega todas las keys nuevas que no estén trackeadas

--- a/tests/test_readers_and_writers.py
+++ b/tests/test_readers_and_writers.py
@@ -158,6 +158,19 @@ revíselo manualmente""".format(temp_filename)
 
         self.assertDictEqual(actual_catalog, expected_catalog)
 
+    def test_read_written_xlsx_catalog(self):
+        """read_catalog puede leer XLSX creado por write_xlsx_catalog"""
+        original_catalog = pydatajson.DataJson(
+            os.path.join(self.SAMPLES_DIR, "catalogo_justicia.json"))
+
+        tmp_xlsx = os.path.join(self.TEMP_DIR, "xlsx_catalog.xlsx")
+        pydatajson.writers.write_xlsx_catalog(original_catalog, tmp_xlsx)
+
+        try:
+            pydatajson.readers.read_xlsx_catalog(tmp_xlsx)
+        except:
+            self.fail("No se pudo leer archivo XLSX")
+
     def test_read_local_xlsx_catalog_with_defaults(self):
         """read_catalog puede leer con valores default."""
         expected_catalog = pydatajson.readers.read_catalog(


### PR DESCRIPTION
Si se escribe un catálogo con `write_xlsx_catalog` y luego se intenta leerlo con `read_xlsx_catalog`, se da el siguiente error:

```python
Traceback (most recent call last):
  File "/home/federico/Workspace/datos/pydatajson/tests/test_readers_and_writers.py", line 169, in test_read_written_xlsx_catalog
    read_catalog = pydatajson.readers.read_xlsx_catalog(tmp_xlsx)
  File "/home/federico/Workspace/datos/pydatajson/pydatajson/readers.py", line 223, in read_xlsx_catalog
    catalog_dict = read_local_xlsx_catalog(xlsx_path_or_url)
  File "/home/federico/Workspace/datos/pydatajson/pydatajson/readers.py", line 411, in read_local_xlsx_catalog
    field["distribution_identifier"], field["distribution_title"],
KeyError: 'distribution_title'
```