### PR TITLE
90 mover super theme a theme

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -94,6 +94,8 @@ Toma los siguientes parámetros:
   - **portal_url**: URL del portal de CKAN de destino.
   - **apikey**: La apikey de un usuario del portal de destino con los permisos para crear el dataset bajo la
   organización pasada como parámetro.
+  - **demote_superThemes** (opcional, default: True):Si está en true, los ids de los themes del dataset, se escriben
+  como groups de CKAN.
   
   Retorna el id en el nodo de destino del dataset federado.
   

--- a/pydatajson/ckan_utils.py
+++ b/pydatajson/ckan_utils.py
@@ -14,7 +14,7 @@ def append_attribute_to_extra(package, dataset, attribute, serialize=False):
         package['extras'].append({'key': attribute, 'value': value})
 
 
-def map_dataset_to_package(dataset, catalog_id):
+def map_dataset_to_package(dataset, catalog_id, demote_superThemes=True):
     package = dict()
     package['extras'] = []
 #   Obligatorios
@@ -32,8 +32,10 @@ def map_dataset_to_package(dataset, catalog_id):
     package['resources'] = map_distributions_to_resources(distributions, catalog_id)
 
     super_themes = dataset['superTheme']
-    package['groups'] = [{'name': title_to_name(super_theme, decode=False)} for super_theme in super_themes]
     append_attribute_to_extra(package, dataset, 'superTheme', serialize=True)
+    if demote_superThemes:
+        package['groups'] = [{'name': title_to_name(super_theme, decode=False)} for super_theme in super_themes]
+
 
 #   Recomendados y opcionales
     package['url'] = dataset.get('landingPage')

--- a/pydatajson/ckan_utils.py
+++ b/pydatajson/ckan_utils.py
@@ -69,7 +69,8 @@ def map_dataset_to_package(dataset, catalog_id, owner_org, theme_taxonomy,
             label = next(x['label'] for x in theme_taxonomy if x['id'] == theme)
             package['tags'].append({'name': label})
     else:
-        package['groups'] += [{'name': title_to_name(theme, decode=False)} for theme in themes]
+        package['groups'] = package.get('groups', []) + [{'name': title_to_name(theme, decode=False)}
+                                                         for theme in themes]
 
     return package
 

--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -9,7 +9,8 @@ from .ckan_utils import map_dataset_to_package
 from .search import get_datasets
 
 
-def push_dataset_to_ckan(catalog, catalog_id, owner_org, dataset_origin_identifier, portal_url, apikey):
+def push_dataset_to_ckan(catalog, catalog_id, owner_org, dataset_origin_identifier, portal_url, apikey,
+                         demote_superThemes=True):
     """Escribe la metadata de un dataset en el portal pasado por parámetro.
 
         Args:
@@ -26,7 +27,7 @@ def push_dataset_to_ckan(catalog, catalog_id, owner_org, dataset_origin_identifi
     dataset = catalog.get_dataset(dataset_origin_identifier)
     ckan_portal = RemoteCKAN(portal_url, apikey=apikey)
 
-    package = map_dataset_to_package(dataset, catalog_id)
+    package = map_dataset_to_package(dataset, catalog_id, demote_superThemes)
     package['owner_org'] = owner_org
 
     # Get license id

--- a/tests/test_ckan_utils.py
+++ b/tests/test_ckan_utils.py
@@ -58,6 +58,22 @@ class DatasetConversionTestCase(unittest.TestCase):
         except AttributeError:
             self.assertCountEqual(keywords, tags)
 
+    def test_superThemes_dont_impact_groups_if_not_demoted(self):
+        package = map_dataset_to_package(self.dataset, self.catalog_id, demote_superThemes=False)
+
+        groups = [group['name'] for group in package.get('groups', [])]
+        tags = [tag['name'] for tag in package['tags']]
+        keywords = self.dataset.get('keyword', [])
+
+        try:
+            self.assertItemsEqual([], groups)
+        except AttributeError:
+            self.assertCountEqual([], groups)
+        try:
+            self.assertItemsEqual(keywords, tags)
+        except AttributeError:
+            self.assertCountEqual(keywords, tags)
+
     def test_dataset_extra_attributes_are_correct(self):
         package = map_dataset_to_package(self.dataset, self.catalog_id)
 #       extras are included in dataset

--- a/tests/test_ckan_utils.py
+++ b/tests/test_ckan_utils.py
@@ -85,9 +85,8 @@ class DatasetConversionTestCase(unittest.TestCase):
             self.assertCountEqual(keywords, tags)
 
     def test_superThemes_dont_impact_groups_if_not_demoted(self):
-        package = map_dataset_to_package(self.dataset, self.catalog_id,'owner',
+        package = map_dataset_to_package(self.dataset, self.catalog_id, 'owner',
                                          self.catalog.themes, demote_superThemes=False)
-
         groups = [group['name'] for group in package.get('groups', [])]
         tags = [tag['name'] for tag in package['tags']]
         keywords = self.dataset.get('keyword', [])
@@ -96,7 +95,6 @@ class DatasetConversionTestCase(unittest.TestCase):
         for theme in themes:
             label = next(x['label'] for x in self.catalog.themes if x['id'] == theme)
             theme_labels.append(label)
-
         try:
             self.assertItemsEqual([], groups)
         except AttributeError:
@@ -106,15 +104,28 @@ class DatasetConversionTestCase(unittest.TestCase):
         except AttributeError:
             self.assertCountEqual(keywords + theme_labels, tags)
 
+    def test_preserve_themes_and_superThemes(self):
+        package = map_dataset_to_package(self.dataset, self.catalog_id, 'owner',
+                                         self.catalog.themes, False, False)
+        groups = [group['name'] for group in package.get('groups', [])]
+        tags = [tag['name'] for tag in package['tags']]
+        keywords = self.dataset.get('keyword', [])
+        themes = self.dataset.get('theme', [])
+        try:
+            self.assertItemsEqual(themes, groups)
+        except AttributeError:
+            self.assertCountEqual(themes, groups)
+        try:
+            self.assertItemsEqual(keywords, tags)
+        except AttributeError:
+            self.assertCountEqual(keywords, tags)
+
     def test_dataset_extra_attributes_are_correct(self):
         package = map_dataset_to_package(self.dataset, self.catalog_id, 'owner', self.catalog.themes)
 #       extras are included in dataset
         if package['extras']:
             for extra in package['extras']:
-                if extra['key'] == 'super_theme':
-                    dataset_value = self.dataset['superTheme']
-                else:
-                    dataset_value = self.dataset[extra['key']]
+                dataset_value = self.dataset[extra['key']]
                 if type(dataset_value) is list:
                     extra_value = json.loads(extra['value'])
                     try:
@@ -137,7 +148,8 @@ class DatasetConversionTestCase(unittest.TestCase):
                 resulting_dict = {'key': key, 'value': value}
                 self.assertTrue(resulting_dict in package['extras'])
 
-        self.assertTrue({'key': 'super_theme', 'value': json.dumps(self.dataset['superTheme'])})
+        self.assertTrue({'key': 'superTheme', 'value': json.dumps(self.dataset['superTheme'])}
+                        in package['extras'])
 
     def test_resources_replicated_attributes_stay_the_same(self):
         resources = map_distributions_to_resources(self.distributions, self.catalog_id+'_'+self.dataset_id)

--- a/tests/test_ckan_utils.py
+++ b/tests/test_ckan_utils.py
@@ -139,7 +139,7 @@ class DatasetConversionTestCase(unittest.TestCase):
     def test_dataset_extra_attributes_are_complete(self):
         package = map_dataset_to_package(self.dataset, self.catalog_id, 'owner', self.catalog.themes)
 #       dataset attributes are included in extras
-        extra_attrs = ['issued', 'modified', 'accrualPeriodicity', 'temporal', 'language', 'spatial']
+        extra_attrs = ['issued', 'modified', 'accrualPeriodicity', 'temporal', 'language', 'spatial', 'superTheme']
         for key in extra_attrs:
             value = self.dataset.get(key)
             if value:
@@ -147,9 +147,6 @@ class DatasetConversionTestCase(unittest.TestCase):
                     value = json.dumps(value)
                 resulting_dict = {'key': key, 'value': value}
                 self.assertTrue(resulting_dict in package['extras'])
-
-        self.assertTrue({'key': 'superTheme', 'value': json.dumps(self.dataset['superTheme'])}
-                        in package['extras'])
 
     def test_resources_replicated_attributes_stay_the_same(self):
         resources = map_distributions_to_resources(self.distributions, self.catalog_id+'_'+self.dataset_id)


### PR DESCRIPTION
Closes #90 

Agrega el parámetro opcional `demote_superTheme` a `push_dataset_to_ckan()`.  Si está en True, propaga los ids de los superTheme a los grupos del paquete de CKAN. 