### PR TITLE
130 mejorar el manejo de themes

### DIFF
--- a/pydatajson/ckan_utils.py
+++ b/pydatajson/ckan_utils.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import json
 import re
+import sys
 from datetime import time
 from dateutil import parser, tz
 from .helpers import title_to_name
@@ -68,7 +69,9 @@ def map_dataset_to_package(catalog, dataset, owner_org, catalog_id=None,
         package['tags'] = package.get('tags', [])
         for theme in themes:
             label = catalog.get_theme(identifier=theme)['label']
-            label = re.sub(r'[^\wá-úÁ-Ú .-]+', '', label)
+            if sys.version_info < (3, 0):
+                label = label.encode('utf8')
+            label = re.sub(r'[^\wá-úÁ-ÚñÑ .-]+', '', label)
             package['tags'].append({'name': label})
     else:
         package['groups'] = package.get('groups', []) + [{'name': title_to_name(theme, decode=False)}

--- a/pydatajson/ckan_utils.py
+++ b/pydatajson/ckan_utils.py
@@ -69,9 +69,7 @@ def map_dataset_to_package(catalog, dataset, owner_org, catalog_id=None,
         package['tags'] = package.get('tags', [])
         for theme in themes:
             label = catalog.get_theme(identifier=theme)['label']
-            if sys.version_info < (3, 0) and not isinstance(label, str):
-                label = label.encode('utf8')
-            label = re.sub(r'[^\wá-úÁ-ÚñÑ .-]+', '', label)
+            label = re.sub(r'[^\wá-úÁ-ÚñÑ .-]+', '', label, flags=re.UNICODE)
             package['tags'].append({'name': label})
     else:
         package['groups'] = package.get('groups', []) + [{'name': title_to_name(theme, decode=False)}

--- a/pydatajson/ckan_utils.py
+++ b/pydatajson/ckan_utils.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import json
+import re
 from datetime import time
 from dateutil import parser, tz
 from .helpers import title_to_name
@@ -14,7 +15,7 @@ def append_attribute_to_extra(package, dataset, attribute, serialize=False):
         package['extras'].append({'key': attribute, 'value': value})
 
 
-def map_dataset_to_package(dataset, owner_org, theme_taxonomy, catalog_id=None,
+def map_dataset_to_package(catalog, dataset, owner_org, catalog_id=None,
                            demote_superThemes=True, demote_themes=True):
     package = dict()
     package['extras'] = []
@@ -66,7 +67,8 @@ def map_dataset_to_package(dataset, owner_org, theme_taxonomy, catalog_id=None,
     if themes and demote_themes:
         package['tags'] = package.get('tags', [])
         for theme in themes:
-            label = next(x['label'] for x in theme_taxonomy if x['id'] == theme)
+            label = catalog.get_theme(identifier=theme)['label']
+            label = re.sub(r'[^\wá-úÁ-Ú .-]+', '', label)
             package['tags'].append({'name': label})
     else:
         package['groups'] = package.get('groups', []) + [{'name': title_to_name(theme, decode=False)}

--- a/pydatajson/ckan_utils.py
+++ b/pydatajson/ckan_utils.py
@@ -69,7 +69,7 @@ def map_dataset_to_package(catalog, dataset, owner_org, catalog_id=None,
         package['tags'] = package.get('tags', [])
         for theme in themes:
             label = catalog.get_theme(identifier=theme)['label']
-            if sys.version_info < (3, 0):
+            if sys.version_info < (3, 0) and not isinstance(label, str):
                 label = label.encode('utf8')
             label = re.sub(r'[^\wá-úÁ-ÚñÑ .-]+', '', label)
             package['tags'].append({'name': label})

--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -29,9 +29,8 @@ def push_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier, portal_u
     """
     dataset = catalog.get_dataset(dataset_origin_identifier)
     ckan_portal = RemoteCKAN(portal_url, apikey=apikey)
-    theme_taxonomy = catalog.themes
 
-    package = map_dataset_to_package(dataset, owner_org, theme_taxonomy, catalog_id,
+    package = map_dataset_to_package(catalog, dataset, owner_org, catalog_id,
                                      demote_superThemes, demote_themes)
 
     # Get license id

--- a/pydatajson/search.py
+++ b/pydatajson/search.py
@@ -280,7 +280,7 @@ def get_theme(catalog, identifier=None, label=None):
 
     # filtra por id (preferentemente) o label
     if identifier:
-        filtered_themes = [theme for theme in themes if theme["id"] == identifier]
+        filtered_themes = [theme for theme in themes if theme["id"].lower() == identifier.lower()]
         if len(filtered_themes) > 1:
             raise ThemeIdRepeated([x["id"] for x in filtered_themes])
 

--- a/tests/samples/full_data.json
+++ b/tests/samples/full_data.json
@@ -193,7 +193,7 @@
             "id": "convocatorias"
         },
         {
-            "label": "Compras",
+            "label": "Adquisición",
             "description": "Datasets sobre compras realizadas.",
             "id": "compras"
         },
@@ -213,7 +213,7 @@
             "id": "normativa"
         },
         {
-            "label": "Proveedores",
+            "label": "Proveeduría",
             "description": "Datasets sobre proveedores del Estado.",
             "id": "proveedores"
         }

--- a/tests/test_ckan_utils.py
+++ b/tests/test_ckan_utils.py
@@ -70,9 +70,7 @@ class DatasetConversionTestCase(unittest.TestCase):
         theme_labels = []
         for theme in themes:
             label = self.catalog.get_theme(identifier=theme)['label']
-            if sys.version_info < (3, 0) and not isinstance(label, str):
-                label = label.encode('utf8')
-            label = re.sub(r'[^\wá-úÁ-Ú .-]+', '', label)
+            label = re.sub(r'[^\w .-]+', '', label, flags=re.UNICODE)
             theme_labels.append(label)
 
         try:
@@ -108,9 +106,7 @@ class DatasetConversionTestCase(unittest.TestCase):
         theme_labels = []
         for theme in themes:
             label = self.catalog.get_theme(identifier=theme)['label']
-            if sys.version_info < (3, 0) and not isinstance(label, str):
-                label = label.encode('utf8')
-            label = re.sub(r'[^\wá-úÁ-Ú .-]+', '', label)
+            label = re.sub(r'[^\wá-úÁ-ÚñÑ .-]+', '', label, flags=re.UNICODE)
             theme_labels.append(label)
         try:
             self.assertItemsEqual([], groups)

--- a/tests/test_ckan_utils.py
+++ b/tests/test_ckan_utils.py
@@ -4,6 +4,7 @@ import unittest
 import os
 import json
 import re
+import sys
 from dateutil import parser, tz
 from .context import pydatajson
 from pydatajson.ckan_utils import map_dataset_to_package, map_distributions_to_resources, convert_iso_string_to_utc
@@ -68,7 +69,9 @@ class DatasetConversionTestCase(unittest.TestCase):
         themes = self.dataset.get('theme', [])
         theme_labels = []
         for theme in themes:
-            label = next(x['label'] for x in self.catalog.themes if x['id'] == theme)
+            label = self.catalog.get_theme(identifier=theme)['label']
+            if sys.version_info < (3, 0) and not isinstance(label, str):
+                label = label.encode('utf8')
             label = re.sub(r'[^\wá-úÁ-Ú .-]+', '', label)
             theme_labels.append(label)
 
@@ -104,7 +107,10 @@ class DatasetConversionTestCase(unittest.TestCase):
         themes = self.dataset.get('theme', [])
         theme_labels = []
         for theme in themes:
-            label = next(x['label'] for x in self.catalog.themes if x['id'] == theme)
+            label = self.catalog.get_theme(identifier=theme)['label']
+            if sys.version_info < (3, 0) and not isinstance(label, str):
+                label = label.encode('utf8')
+            label = re.sub(r'[^\wá-úÁ-Ú .-]+', '', label)
             theme_labels.append(label)
         try:
             self.assertItemsEqual([], groups)

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -89,9 +89,7 @@ class PushDatasetTestCase(unittest.TestCase):
         keywords = [kw for kw in self.dataset['keyword']]
         for theme in themes:
             label = self.catalog.get_theme(identifier=theme)['label']
-            if sys.version_info < (3, 0) and not isinstance(label, str):
-                label = label.encode('utf8')
-            label = re.sub(r'[^\wá-úÁ-Ú .-]+', '', label)
+            label = re.sub(r'[^\w .-]+', '', label, flags=re.UNICODE)
             keywords.append(label)
 
         def mock_call_action(action, data_dict=None):

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -1,6 +1,9 @@
+# -*- coding: utf-8 -*-
+
 import unittest
 import os
 import re
+import sys
 try:
     from mock import patch, MagicMock
 except ImportError:
@@ -83,10 +86,12 @@ class PushDatasetTestCase(unittest.TestCase):
     @patch('pydatajson.federation.RemoteCKAN', autospec=True)
     def test_tags_are_passed_correctly(self, mock_portal):
         themes = self.dataset['theme']
-        theme_taxonomy = self.catalog.themes
         keywords = [kw for kw in self.dataset['keyword']]
         for theme in themes:
-            label = next(x['label'] for x in theme_taxonomy if x['id'] == theme)
+            label = self.catalog.get_theme(identifier=theme)['label']
+            if sys.version_info < (3, 0) and not isinstance(label, str):
+                label = label.encode('utf8')
+            label = re.sub(r'[^\wá-úÁ-Ú .-]+', '', label)
             keywords.append(label)
 
         def mock_call_action(action, data_dict=None):


### PR DESCRIPTION
Closes #130 

-Hace la comparación de id de `themes` de un dataset y su entrada en el `theme_taxonomy` case insensitive

-Remueve caracteres no permitidos de los `labels` de los `themes` cuando se pasan como tags.