### PR TITLE
132 push theme to ckan

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -107,7 +107,7 @@ Toma los siguientes parámetros:
   mantener una consistencia más estricta dentro del catálogo a federar, es necesario validar los datos antes de pasarlos
   a la función. 
 
-- **pydatajson.DataJson.remove_dataset_from_ckan()**: Hace un borrado físico de un dataset en un portal de CKAN.
+- **pydatajson.federation.remove_dataset_from_ckan()**: Hace un borrado físico de un dataset en un portal de CKAN.
 Toma los siguientes parámetros:
     - **portal_url**: La URL del portal CKAN. Debe implementar la funcionalidad de `/data.json`.
     - **apikey**: La apikey de un usuario con los permisos que le permitan borrar el dataset.
@@ -120,6 +120,16 @@ Toma los siguientes parámetros:
     
     En caso de pasar más de un parámetro opcional, la función `remove_dataset_from_ckan()` borra aquellos datasets que
     cumplan con todas las condiciones.
+
+- **pydatajson.DataJson.push_theme_to_ckan()**: Crea un tema en el portal de destino
+Toma los siguientes parámetros:
+    - **portal_url**: La URL del portal CKAN. Debe implementar la funcionalidad de `/data.json`.
+    - **apikey**: La apikey de un usuario con los permisos que le permitan borrar el dataset.
+    - **identifier** (opcional, default: None): Id del `theme` que se quiere federar, en el catálogo de origen.
+    - **label** (opcional, default: None): label del `theme` que se quiere federar, en el catálogo de origen.
+
+    Debe pasarse por lo menos uno de los 2 parámetros opcionales. En caso de que se provean los 2, se prioriza el
+    identifier sobre el label.
 
 ## Uso
     

--- a/pydatajson/ckan_utils.py
+++ b/pydatajson/ckan_utils.py
@@ -120,13 +120,9 @@ def map_distributions_to_resources(distributions, catalog_id=None):
 
 
 def map_theme_to_group(theme):
-    group = dict()
-    identifier = theme.get('id')
-    if identifier:
-        group['name'] = title_to_name(identifier)
-    else:
-        # Si no tiene id, seguro tiene label
-        group['name'] = title_to_name(theme['label'])
-    group['title'] = theme.get('label')
-    group['description'] = theme.get('description')
-    return group
+
+    return {
+        "name": title_to_name(theme.get('id') or theme['label']),
+        "title": theme.get('label'),
+        "description": theme.get('description'),
+    }

--- a/pydatajson/ckan_utils.py
+++ b/pydatajson/ckan_utils.py
@@ -121,14 +121,12 @@ def map_distributions_to_resources(distributions, catalog_id=None):
 
 def map_theme_to_group(theme):
     group = dict()
-
     identifier = theme.get('id')
     if identifier:
         group['name'] = title_to_name(identifier)
     else:
         # Si no tiene id, seguro tiene label
         group['name'] = title_to_name(theme['label'])
-
     group['title'] = theme.get('label')
     group['description'] = theme.get('description')
     return group

--- a/pydatajson/ckan_utils.py
+++ b/pydatajson/ckan_utils.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 import json
 import re
-import sys
 from datetime import time
 from dateutil import parser, tz
 from .helpers import title_to_name
@@ -109,10 +108,27 @@ def map_distributions_to_resources(distributions, catalog_id=None):
         resource['mimetype'] = distribution.get('mediaType')
         resource['size'] = distribution.get('byteSize')
         resource['accessURL'] = distribution.get('accessURL')
-        resource['fileName'] = distribution.get('fileName')
+        fileName = distribution.get('fileName')
+        if fileName:
+            resource['fileName'] = fileName
         dist_fields = distribution.get('field')
         if dist_fields:
             resource['attributesDescription'] = json.dumps(dist_fields)
         resources.append(resource)
 
     return resources
+
+
+def map_theme_to_group(theme):
+    group = dict()
+
+    identifier = theme.get('id')
+    if identifier:
+        group['name'] = title_to_name(identifier)
+    else:
+        # Si no tiene id, seguro tiene label
+        group['name'] = title_to_name(theme['label'])
+
+    group['title'] = theme.get('label')
+    group['description'] = theme.get('description')
+    return group

--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -5,7 +5,7 @@
 from __future__ import print_function
 from ckanapi import RemoteCKAN
 from ckanapi.errors import NotFound
-from .ckan_utils import map_dataset_to_package
+from .ckan_utils import map_dataset_to_package, map_theme_to_group
 from .search import get_datasets
 
 
@@ -103,3 +103,11 @@ def remove_datasets_from_ckan(portal_url, apikey, filter_in=None, filter_out=Non
 
     for identifier in identifiers:
         ckan_portal.call_action('dataset_purge', data_dict={'id': identifier})
+
+
+def push_theme_to_ckan(catalog, portal_url, apikey, identifier=None, label=None):
+    ckan_portal = RemoteCKAN(portal_url, apikey=apikey)
+    theme = catalog.get_theme(identifier=identifier, label=label)
+    group = map_theme_to_group(theme)
+    pushed_group = ckan_portal.call_action('group_create', data_dict=group)
+    return pushed_group['name']

--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -23,7 +23,6 @@ def push_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier, portal_u
             demote_superThemes(bool): Si está en true, los ids de los super themes del dataset, se propagan como grupo.
             demote_themes(bool): Si está en true, los labels de los themes del dataset, pasan a ser tags. Sino,
             se pasan como grupo.
-
         Returns:
             str: El id del dataset en el catálogo de destino.
     """
@@ -106,6 +105,17 @@ def remove_datasets_from_ckan(portal_url, apikey, filter_in=None, filter_out=Non
 
 
 def push_theme_to_ckan(catalog, portal_url, apikey, identifier=None, label=None):
+    """Escribe la metadata de un theme en el portal pasado por parámetro.
+
+            Args:
+                catalog (DataJson): El catálogo de origen que contiene el theme.
+                portal_url (str): La URL del portal CKAN de destino.
+                apikey (str): La apikey de un usuario con los permisos que le permitan crear o actualizar el dataset.
+                identifier (str): El identificador para buscar el theme en la taxonomia.
+                label (str): El label para buscar el theme en la taxonomia.
+            Returns:
+                str: El name del theme en el catálogo de destino.
+        """
     ckan_portal = RemoteCKAN(portal_url, apikey=apikey)
     theme = catalog.get_theme(identifier=identifier, label=label)
     group = map_theme_to_group(theme)


### PR DESCRIPTION
Closes #132 

Implementa la funcionalidad de `push_theme_to_ckan()`.  La función toma un catálogo y un identificador o label de theme y copia la metadata al portal pasado como parámetro de acuerdo a la especificación 1.1 del perfil de metadatos.