### PR TITLE
128 wrappers para push dataset to ckan

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -87,7 +87,7 @@ Existen dos métodos, cuyos reportes se incluyen diariamente entre los archivos 
 ### Métodos para federación de datasets
 
 - **pydatajson.DataJson.push_dataset_to_ckan()**: Copia la metadata de un dataset y la escribe en un portal de CKAN.
-Toma los siguientes parámetros: 
+Toma los siguientes parámetros:
   - **owner_org**: La organización a la que pertence el dataset. Debe encontrarse en el portal de destino.
   - **dataset_origin_identifier**: Identificador del dataset en el catálogo de origen.
   - **portal_url**: URL del portal de CKAN de destino.
@@ -100,7 +100,7 @@ Toma los siguientes parámetros:
   - **demote_themes** (opcional, default: True): Si está en true, los labels de los themes del dataset, se escriben como
   tags de CKAN; sino,se pasan como grupo.
 
-  
+
   Retorna el id en el nodo de destino del dataset federado.
   
   **Advertencia**: La función `push_dataset_to_ckan()` sólo garantiza consistencia con los estándares de CKAN. Para
@@ -123,13 +123,62 @@ Toma los siguientes parámetros:
 
 - **pydatajson.DataJson.push_theme_to_ckan()**: Crea un tema en el portal de destino
 Toma los siguientes parámetros:
-    - **portal_url**: La URL del portal CKAN. Debe implementar la funcionalidad de `/data.json`.
-    - **apikey**: La apikey de un usuario con los permisos que le permitan borrar el dataset.
+    - **portal_url**: La URL del portal CKAN.
+    - **apikey**: La apikey de un usuario con los permisos que le permitan crear un grupo.
     - **identifier** (opcional, default: None): Id del `theme` que se quiere federar, en el catálogo de origen.
     - **label** (opcional, default: None): label del `theme` que se quiere federar, en el catálogo de origen.
 
     Debe pasarse por lo menos uno de los 2 parámetros opcionales. En caso de que se provean los 2, se prioriza el
     identifier sobre el label.
+
+- **pydatajson.DataJson.push_new_themes()**: Toma los temas de la taxonomía de un DataJson y los crea en el catálogo de
+    destino si no existen.
+Toma los siguientes parámetros:
+    - **portal_url**: La URL del portal CKAN adonde se escribiran los temas.
+    - **apikey**: La apikey de un usuario con los permisos que le permitan crear los grupos.
+
+
+Hay también funciones que facilitan el uso de `push_dataset_to_ckan()`:
+
+- **pydatajson.DataJson.harvest_dataset_to_ckan()**: Federa la metadata de un dataset en un portal de CKAN.
+Toma los siguientes parámetros:
+  - **owner_org**: La organización a la que pertence el dataset. Debe encontrarse en el portal de destino.
+  - **dataset_origin_identifier**: Identificador del dataset en el catálogo de origen.
+  - **portal_url**: URL del portal de CKAN de destino.
+  - **apikey**: La apikey de un usuario del portal de destino con los permisos para crear el dataset bajo la
+  organización pasada como parámetro.
+  - **catalog_id**: El prefijo que va a preceder el id y name del dataset en el portal
+  destino, separado por un guión.
+
+
+  Retorna el id en el nodo de destino del dataset federado.
+
+- **pydatajson.DataJson.restore_dataset_to_ckan()**: Restaura la metadata de un dataset en un portal de CKAN.
+Toma los siguientes parámetros:
+  - **owner_org**: La organización a la que pertence el dataset. Debe encontrarse en el portal de destino.
+  - **dataset_origin_identifier**: Identificador del dataset en el catálogo de origen.
+  - **portal_url**: URL del portal de CKAN de destino.
+  - **apikey**: La apikey de un usuario del portal de destino con los permisos para crear el dataset bajo la
+  organización pasada como parámetro.
+
+
+  Retorna el id del dataset restaurado.
+
+- **pydatajson.DataJson.harvest_catalog_to_ckan()**: Federa los datasets de un catálogo al portal pasado por parámetro.
+Toma los siguientes parámetros:
+  - **dataset_origin_identifier**: Identificador del dataset en el catálogo de origen.
+  - **portal_url**: URL del portal de CKAN de destino.
+  - **apikey**: La apikey de un usuario del portal de destino con los permisos para crear el dataset.
+  - **catalog_id**: El prefijo que va a preceder el id y name del dataset en el portal
+  destino, separado por un guión.
+  - **dataset_list** (opcional, default: None): Lista de ids de los datasets a federar. Si no se pasa, se federan todos
+  los datasets del catálogo.
+  - **owner_org** (opcional, default: None): La organización a la que pertence el dataset. Debe encontrarse en el
+  portal de destino. Si no se pasa, se toma como organización el catalog_id
+
+
+  Retorna el id en el nodo de destino de los datasets federados.
+
 
 ## Uso
     

--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -124,13 +124,11 @@ def push_theme_to_ckan(catalog, portal_url, apikey, identifier=None, label=None)
 
 
 def restore_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier, portal_url, apikey):
-
     return push_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier,
                                 portal_url, apikey, None, False, False)
 
 
 def harvest_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier, portal_url, apikey, catalog_id):
-
     return push_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier,
                                 portal_url, apikey, catalog_id=catalog_id)
 
@@ -138,14 +136,20 @@ def harvest_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier, porta
 def restore_catalog_to_ckan(catalog, owner_org, portal_url, apikey, dataset_list=None):
     push_new_themes(catalog, portal_url, apikey)
     dataset_list = dataset_list or [ds['identifier'] for ds in catalog.datasets]
+    restored = []
     for dataset_id in dataset_list:
-        restore_dataset_to_ckan(catalog, owner_org, dataset_id, portal_url, apikey)
+        restored_id = restore_dataset_to_ckan(catalog, owner_org, dataset_id, portal_url, apikey)
+        restored.append(restored_id)
+    return restored
 
 
 def harvest_catalog_to_ckan(catalog, owner_org, portal_url, apikey, catalog_id, dataset_list=None):
     dataset_list = dataset_list or [ds['identifier'] for ds in catalog.datasets]
+    harvested = []
     for dataset_id in dataset_list:
-        harvest_dataset_to_ckan(catalog, owner_org, dataset_id, portal_url, apikey, catalog_id)
+        harvested_id = harvest_dataset_to_ckan(catalog, owner_org, dataset_id, portal_url, apikey, catalog_id)
+        harvested.append(harvested_id)
+    return harvested
 
 
 def push_new_themes(catalog, portal_url, apikey):

--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -134,3 +134,24 @@ def harvest_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier, porta
     return push_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier,
                                 portal_url, apikey, catalog_id=catalog_id)
 
+
+def restore_catalog_to_ckan(catalog, owner_org, portal_url, apikey, dataset_list=None):
+    push_new_themes(catalog, portal_url, apikey)
+    dataset_list = dataset_list or [ds['identifier'] for ds in catalog.datasets]
+    for dataset_id in dataset_list:
+        restore_dataset_to_ckan(catalog, owner_org, dataset_id, portal_url, apikey)
+
+
+def harvest_catalog_to_ckan(catalog, owner_org, portal_url, apikey, catalog_id, dataset_list=None):
+    dataset_list = dataset_list or [ds['identifier'] for ds in catalog.datasets]
+    for dataset_id in dataset_list:
+        harvest_dataset_to_ckan(catalog, owner_org, dataset_id, portal_url, apikey, catalog_id)
+
+
+def push_new_themes(catalog, portal_url, apikey):
+    ckan_portal = RemoteCKAN(portal_url, apikey=apikey)
+    existing_themes = ckan_portal.call_action('group_list')
+    new_themes = [theme['id'] for theme in catalog['themes'] if theme['id'] not in existing_themes]
+    for new_theme in new_themes:
+        push_theme_to_ckan(catalog, portal_url, apikey, identifier=new_theme)
+    return new_themes

--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -215,7 +215,9 @@ def push_new_themes(catalog, portal_url, apikey):
     """
     ckan_portal = RemoteCKAN(portal_url, apikey=apikey)
     existing_themes = ckan_portal.call_action('group_list')
-    new_themes = [theme['id'] for theme in catalog['themes'] if theme['id'] not in existing_themes]
+    new_themes = [theme['id'] for theme in catalog['themeTaxonomy'] if theme['id'] not in existing_themes]
+    pushed_names = []
     for new_theme in new_themes:
-        push_theme_to_ckan(catalog, portal_url, apikey, identifier=new_theme)
-    return new_themes
+        name = push_theme_to_ckan(catalog, portal_url, apikey, identifier=new_theme)
+        pushed_names.append(name)
+    return pushed_names

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -46,7 +46,7 @@ class PushDatasetTestCase(unittest.TestCase):
             if action == 'package_update':
                 raise NotFound
             if action == 'package_create':
-                return {'id': data_dict['id']}
+                return data_dict
             else:
                 return []
         mock_portal.return_value.call_action = mock_call_action
@@ -58,7 +58,7 @@ class PushDatasetTestCase(unittest.TestCase):
     def test_id_is_updated_correctly(self, mock_portal):
         def mock_call_action(action, data_dict=None):
             if action == 'package_update':
-                return {'id': data_dict['id']}
+                return data_dict
             if action == 'package_create':
                 self.fail('should not be called')
             else:
@@ -72,7 +72,7 @@ class PushDatasetTestCase(unittest.TestCase):
     def test_dataset_id_is_preserved_if_catalog_id_is_not_passed(self, mock_portal):
         def mock_call_action(action, data_dict=None):
             if action == 'package_update':
-                return {'id': data_dict['id']}
+                return data_dict
             if action == 'package_create':
                 self.fail('should not be called')
             else:
@@ -98,7 +98,7 @@ class PushDatasetTestCase(unittest.TestCase):
                     self.assertItemsEqual(keywords, [tag['name'] for tag in data_dict['tags']])
                 except AttributeError:
                     self.assertCountEqual(keywords, [tag['name'] for tag in data_dict['tags']])
-                return {'id': data_dict['id']}
+                return data_dict
             if action == 'package_create':
                 self.fail('should not be called')
             else:
@@ -117,7 +117,7 @@ class PushDatasetTestCase(unittest.TestCase):
                         {'title': 'otherlicense', 'url': 'otherlicense.com', 'id': '2'}]
             elif action == 'package_update':
                 self.assertEqual('notspecified', data_dict['license_id'])
-                return {'id': data_dict['id']}
+                return data_dict
             else:
                 return []
         mock_portal.return_value.call_action = mock_call_action
@@ -132,7 +132,7 @@ class PushDatasetTestCase(unittest.TestCase):
                         {'title': 'otherlicense', 'url': 'otherlicense.com', 'id': '2'}]
             elif action == 'package_update':
                 self.assertEqual('notspecified', data_dict['license_id'])
-                return {'id': data_dict['id']}
+                return data_dict
             else:
                 return []
 
@@ -144,7 +144,7 @@ class PushDatasetTestCase(unittest.TestCase):
     def test_dataset_level_wrappers(self, mock_portal):
         def mock_call_action(action, data_dict=None):
             if action == 'package_update':
-                return {'id': data_dict['id']}
+                return data_dict
             else:
                 return []
         mock_portal.return_value.call_action = mock_call_action
@@ -154,6 +154,74 @@ class PushDatasetTestCase(unittest.TestCase):
                                                'portal', 'key', self.catalog_id)
         self.assertEqual(self.dataset_id, restored_id)
         self.assertEqual(self.catalog_id+'_'+self.dataset_id, harvested_id)
+    
+    @patch('pydatajson.federation.RemoteCKAN', autospec=True)
+    def test_harvest_catalog_with_no_optional_parametres(self, mock_portal):
+        def mock_call_action(action, data_dict=None):
+            if action == 'package_update':
+                self.assertTrue(data_dict['id'].startswith(self.catalog_id+'_'))
+                self.assertTrue(data_dict['name'].startswith(self.catalog_id+'-'))
+                self.assertEqual(self.catalog_id, data_dict['owner_org'])
+                return data_dict
+            else:
+                return []
+        mock_portal.return_value.call_action = mock_call_action
+        harvested_ids = harvest_catalog_to_ckan(self.catalog, 'portal', 'key', self.catalog_id)
+        try:
+            self.assertItemsEqual([self.catalog_id+'_'+ds['identifier'] for ds in self.catalog.datasets],
+                                  harvested_ids)
+        except AttributeError:
+            self.assertCountEqual([self.catalog_id+'_'+ds['identifier'] for ds in self.catalog.datasets],
+                                  harvested_ids)
+
+    @patch('pydatajson.federation.RemoteCKAN', autospec=True)
+    def test_harvest_catalog_with_dataset_list(self, mock_portal):
+        def mock_call_action(action, data_dict=None):
+            if action == 'package_update':
+                return data_dict
+            else:
+                return []
+
+        mock_portal.return_value.call_action = mock_call_action
+
+        dataset_list = [ds['identifier'] for ds in self.catalog.datasets[:1]]
+        harvested_ids = harvest_catalog_to_ckan(self.catalog, 'portal', 'key', self.catalog_id,
+                                                dataset_list=dataset_list)
+        try:
+            self.assertItemsEqual([self.catalog_id+'_'+ds_id for ds_id in dataset_list],
+                                  harvested_ids)
+        except AttributeError:
+            self.assertCountEqual([self.catalog_id+'_'+ds_id for ds_id in dataset_list],
+                                  harvested_ids)
+
+        dataset_list = [ds['identifier'] for ds in self.catalog.datasets]
+        harvested_ids = harvest_catalog_to_ckan(self.catalog, 'portal', 'key', self.catalog_id,
+                                                dataset_list=dataset_list)
+        try:
+            self.assertItemsEqual([self.catalog_id+'_'+ds_id for ds_id in dataset_list],
+                                  harvested_ids)
+        except AttributeError:
+            self.assertCountEqual([self.catalog_id+'_'+ds_id for ds_id in dataset_list],
+                                  harvested_ids)
+
+    @patch('pydatajson.federation.RemoteCKAN', autospec=True)
+    def test_harvest_catalog_with_owner_org(self, mock_portal):
+        def mock_call_action(action, data_dict=None):
+            if action == 'package_update':
+                self.assertEqual('owner', data_dict['owner_org'])
+                return data_dict
+            else:
+                return []
+
+        mock_portal.return_value.call_action = mock_call_action
+        harvested_ids = harvest_catalog_to_ckan(self.catalog, 'portal', 'key', self.catalog_id,
+                                                owner_org='owner')
+        try:
+            self.assertItemsEqual([self.catalog_id+'_'+ds['identifier'] for ds in self.catalog.datasets],
+                                  harvested_ids)
+        except AttributeError:
+            self.assertCountEqual([self.catalog_id+'_'+ds['identifier'] for ds in self.catalog.datasets],
+                                  harvested_ids)
 
 
 class RemoveDatasetTestCase(unittest.TestCase):


### PR DESCRIPTION
Implementa 3 wrappers: `harvest_dataset_to_ckan()`, `harvest_catalog_to_ckan()` y `restore_dataset_to_ckan()`. Además agrega el método `push_new_themes()` que escribe en un portal de CKAN los temas no presentes de la taxonomía de un catálogo.