### PR TITLE
151 robustecer harvest catalog to ckan()

### DIFF
--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -263,6 +263,7 @@ def harvest_catalog_to_ckan(catalog, portal_url, apikey, catalog_id,
                 catalog, owner_org, dataset_id, portal_url, apikey, catalog_id)
             harvested.append(harvested_id)
         except (NotAuthorized, NotFound, KeyError, TypeError) as e:
+            logger.error("Error federando catalogo:"+catalog_id+", dataset:"+dataset_id + "al portal: "+portal_url)
             logger.error(str(e))
 
     return harvested

--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -5,11 +5,13 @@ de la API de CKAN.
 """
 
 from __future__ import print_function
+import logging
 from ckanapi import RemoteCKAN
-from ckanapi.errors import NotFound
+from ckanapi.errors import NotFound, NotAuthorized
 from .ckan_utils import map_dataset_to_package, map_theme_to_group
 from .search import get_datasets
 
+logger = logging.getLogger(__name__)
 
 def push_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier,
                          portal_url, apikey, catalog_id=None,
@@ -250,14 +252,19 @@ def harvest_catalog_to_ckan(catalog, portal_url, apikey, catalog_id,
         Returns:
             str: El id del dataset en el catálogo de destino.
     """
-    dataset_list = dataset_list or [ds['identifier']
-                                    for ds in catalog.datasets]
+    # Evitar entrar con valor falsy
+    if dataset_list is None:
+        dataset_list = [ds['identifier'] for ds in catalog.datasets]
     owner_org = owner_org or catalog_id
     harvested = []
     for dataset_id in dataset_list:
-        harvested_id = harvest_dataset_to_ckan(
-            catalog, owner_org, dataset_id, portal_url, apikey, catalog_id)
-        harvested.append(harvested_id)
+        try:
+            harvested_id = harvest_dataset_to_ckan(
+                catalog, owner_org, dataset_id, portal_url, apikey, catalog_id)
+            harvested.append(harvested_id)
+        except (NotAuthorized, NotFound, KeyError, TypeError) as e:
+            logger.error(str(e))
+
     return harvested
 
 

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -223,6 +223,13 @@ class PushDatasetTestCase(unittest.TestCase):
             self.assertCountEqual([self.catalog_id+'_'+ds['identifier'] for ds in self.catalog.datasets],
                                   harvested_ids)
 
+    @patch('pydatajson.federation.RemoteCKAN', autospec=True)
+    def test_harvest_catalog_with_empty_list(self, mock_portal):
+        harvested_ids = harvest_catalog_to_ckan(self.catalog, 'portal', 'key', self.catalog_id,
+                                                owner_org='owner', dataset_list=[])
+        mock_portal.assert_not_called()
+        self.assertEqual([], harvested_ids)
+
 
 class RemoveDatasetTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Closes #151 

`harvest_catalog()` chequea que la lista no sea `None` y loggea las excepciones de `harvest_dataset()` para continuar la federación.