### PR TITLE
fix para functools en py3

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include LICENSE
 include README.md
 include requirements.txt
 include requirements_dev.txt
+include requirements_2.7.txt
 
 recursive-include tests *
 recursive-include pydatajson *

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ unicodecsv==0.14.1
 openpyxl>=2.4,<2.5
 # Para consultar programáticamente la API de CKAN
 ckanapi==4.0
-functools32==3.2.3.post2;python_version<"3.4"
 urllib3==1.22
 Unidecode==0.4.21
 six==1.11.0

--- a/requirements_2.7.txt
+++ b/requirements_2.7.txt
@@ -1,0 +1,1 @@
+functools32==3.2.3.post2

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ with open(os.path.abspath("requirements.txt")) as f:
 with open(os.path.abspath("requirements_dev.txt")) as f:
     test_requirements = [req.strip() for req in f.readlines()]
 
+with open(os.path.abspath("requirements_2.7.txt")) as f:
+    backport_requirements = [req.strip() for req in f.readlines()]
+
 setup(
     name='pydatajson',
     version='0.4.14',
@@ -47,6 +50,9 @@ setup(
     ],
     test_suite='tests',
     tests_require=test_requirements,
+    extras_require={
+        ':python_version=="2.7"': backport_requirements
+    },
     entry_points={
         'console_scripts': [
             'pydatajson = pydatajson.__main__:main'


### PR DESCRIPTION
Closes #156 

Cambia el `setup.py` y los requerimientos para que el marcador de versión esté fuera del txt de requerimientos y pip lo parsee bien.