### PR TITLE
178 arreglar formato lista validacion

### DIFF
--- a/pydatajson/validation.py
+++ b/pydatajson/validation.py
@@ -373,19 +373,23 @@ def _catalog_validation_to_list(response):
     rows_catalog = []
     validation_result = {
         "catalog_title": response["error"]["catalog"]["title"],
-        "catalog_status": response["error"]["catalog"]["status"]
+        "catalog_status": response["error"]["catalog"]["status"],
     }
     for error in response["error"]["catalog"]["errors"]:
-        validation_result[
-            "catalog_error_message"] = error["message"]
-        validation_result[
-            "catalog_error_location"] = ", ".join(error["path"])
-        rows_catalog.append(validation_result)
+        catalog_result = dict(validation_result)
+        catalog_result.update({
+            "catalog_error_message": error["message"],
+            "catalog_error_location": ", ".join(error["path"]),
+        })
+        rows_catalog.append(catalog_result)
 
     if len(response["error"]["catalog"]["errors"]) == 0:
-        validation_result["catalog_error_message"] = None
-        validation_result["catalog_error_location"] = None
-        rows_catalog.append(validation_result)
+        catalog_result = dict(validation_result)
+        catalog_result.update({
+            "catalog_error_message": None,
+            "catalog_error_location": None
+        })
+        rows_catalog.append(catalog_result)
 
     # crea una lista de dicts para volcarse en una tabla (dataset)
     rows_dataset = []
@@ -397,16 +401,20 @@ def _catalog_validation_to_list(response):
             "dataset_status": dataset["status"]
         }
         for error in dataset["errors"]:
-            validation_result[
-                "dataset_error_message"] = error["message"]
-            validation_result[
-                "dataset_error_location"] = error["path"][-1]
-            rows_dataset.append(validation_result)
+            dataset_result = dict(validation_result)
+            dataset_result.update({
+                "dataset_error_message": error["message"],
+                "dataset_error_location": error["path"][-1]
+            })
+            rows_dataset.append(dataset_result)
 
         if len(dataset["errors"]) == 0:
-            validation_result["dataset_error_message"] = None
-            validation_result["dataset_error_location"] = None
-            rows_dataset.append(validation_result)
+            dataset_error = dict(validation_result)
+            dataset_error.update({
+                "dataset_error_message": None,
+                "dataset_error_location": None
+            })
+            rows_dataset.append(dataset_error)
 
     return {"catalog": rows_catalog, "dataset": rows_dataset}
 

--- a/pydatajson/validation.py
+++ b/pydatajson/validation.py
@@ -409,12 +409,12 @@ def _catalog_validation_to_list(response):
             rows_dataset.append(dataset_result)
 
         if len(dataset["errors"]) == 0:
-            dataset_error = dict(validation_result)
-            dataset_error.update({
+            dataset_result = dict(validation_result)
+            dataset_result.update({
                 "dataset_error_message": None,
                 "dataset_error_location": None
             })
-            rows_dataset.append(dataset_error)
+            rows_dataset.append(dataset_result)
 
     return {"catalog": rows_catalog, "dataset": rows_dataset}
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -260,3 +260,24 @@ class TestDataJsonTestCase(object):
             datajson["dataset"][0]["accrualPeriodicity"] = value
             res = self.dj.is_valid_catalog(datajson)
             assert_false(res, msg=value)
+
+    def test_valid_catalog_list_format(self):
+        report_list = self.dj.validate_catalog(fmt='list')
+        assert_true(len(report_list['catalog']) == 1)
+        assert_true(report_list['catalog'][0]['catalog_status'] == 'OK')
+        assert_true(len(report_list['dataset']) == 2)
+        for report in report_list['dataset']:
+            assert_true(report['dataset_status'] == 'OK')
+
+    def test_invalid_catalog_list_format(self):
+        catalog = pydatajson.DataJson(self.get_sample("several_assorted_errors.json"))
+        report_list = catalog.validate_catalog(fmt='list')
+        report_dict = catalog.validate_catalog()
+
+        assert_true(len(report_list['catalog']) == 4)
+        for error in report_dict['error']['catalog']['errors']:
+            assert_true(error['message'] in [reported['catalog_error_message'] for reported in report_list['catalog']])
+
+        assert_true(len(report_list['dataset']) == 5)
+        for error in report_dict['error']['dataset'][0]['errors']:
+            assert_true(error['message'] in [reported['dataset_error_message'] for reported in report_list['dataset']])


### PR DESCRIPTION
Closes #178 

- En la iteración sobre los errores, crea un dicccionario nuevo en vez de pasar la misma referencia siempre.
- Agrega tests para el formato de lista.
