### PR TITLE
Change indicators default value

### DIFF
--- a/pydatajson/indicators.py
+++ b/pydatajson/indicators.py
@@ -163,13 +163,14 @@ def _federation_indicators(catalog, central_catalog):
     """
     result = {
         'datasets_federados_cant': None,
+        'datasets_federados_pct': None,
         'datasets_no_federados_cant': None,
         'datasets_federados_eliminados_cant': None,
-        'datasets_federados_eliminados': None,
-        'datasets_no_federados': None,
-        'datasets_federados': None,
-        'datasets_federados_pct': None,
-        'distribuciones_federadas_cant': None
+        'distribuciones_federadas_cant': None,
+        'datasets_federados_eliminados': [],
+        'datasets_no_federados': [],
+        'datasets_federados': [],
+
     }
     try:
         central_catalog = readers.read_catalog(central_catalog)

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -524,8 +524,11 @@ class TestIndicatorsTestCase(object):
             'datasets_meta_ok_pct': round(100 * float(2) / 3, 2),
             'datasets_federados_cant': None,
             'datasets_no_federados_cant': None,
-            'datasets_no_federados': None,
-            'datasets_federados_pct': None
+            'datasets_federados_pct': None,
+            'datasets_federados': [],
+            'datasets_no_federados': [],
+            'datasets_federados_eliminados': [],
+
         }
         for k, v in expected.items():
             assert_equal(indics[k], v)


### PR DESCRIPTION
- Cambia el valor default de indicadores de listas. (https://github.com/datosgobar/pydatajson/blob/master/pydatajson/helpers.py#L258 Interpreta `None` como 0. Eso rompe en los casos de indicadores de listas)

- Actualiza los tests