### PR TITLE
207 get organization from ckan

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -438,6 +438,16 @@ Toma los siguientes parámetros:
   Retorna una lista de diccionarios con la información de las organizaciones. Recursivamente, dentro del campo `children`,
   se encuentran las organizaciones dependientes en la jerarquía. 
 
+- **pydatajson.federation.get_organization_from_ckan()**: Devuelve un diccionario con la información de una 
+organización en base a un id y un portal pasados por parámetro.
+Toma los siguientes parámetros:
+  - **portal_url**: URL del portal de CKAN. Debe implementar el endpoint `/group_tree`.
+  - **org_id**: Identificador de la organización a buscar.
+  
+  Retorna un diccionario con la información de la organización correspondiente al identificador obtenido. 
+  _No_ incluye su jerarquía, por lo cual ésta deberá ser conseguida mediante el uso de la función 
+  `get_organizations_from_ckan`.
+
 - **pydatajson.federation.push_organization_tree_to_ckan()**: Tomando un árbol de organizaciones como el creado por
 `get_organizations_from_ckan()` crea en el portal de destino las organizaciones dentro de su jerarquía. Toma los siguientes
 parámetros:

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -441,8 +441,8 @@ Toma los siguientes parámetros:
 - **pydatajson.federation.get_organization_from_ckan()**: Devuelve un diccionario con la información de una 
 organización en base a un id y un portal pasados por parámetro.
 Toma los siguientes parámetros:
-  - **portal_url**: URL del portal de CKAN. Debe implementar el endpoint `/group_tree`.
-  - **org_id**: Identificador de la organización a buscar.
+  - **portal_url**: URL del portal de CKAN. Debe implementar el endpoint `/organization_show`.
+  - **org_id**: Identificador o name de la organización a buscar.
   
   Retorna un diccionario con la información de la organización correspondiente al identificador obtenido. 
   _No_ incluye su jerarquía, por lo cual ésta deberá ser conseguida mediante el uso de la función 

--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -308,12 +308,26 @@ def get_organizations_from_ckan(portal_url):
             Args:
                 portal_url (str): La URL del portal CKAN de origen.
             Returns:
-                dict: Diccionarios anidados con la información de
+                list: Lista de diccionarios anidados con la información de
                 las organizaciones.
         """
     ckan_portal = RemoteCKAN(portal_url)
     return ckan_portal.call_action('group_tree',
                                    data_dict={'type': 'organization'})
+
+
+def get_organization_from_ckan(portal_url, org_id):
+    """Toma la url de un portal y un id, y devuelve la organización a buscar.
+
+            Args:
+                portal_url (str): La URL del portal CKAN de origen.
+                org_id (str): El id de la organización a buscar.
+            Returns:
+                dict: Diccionario con la información de la organización.
+        """
+    ckan_portal = RemoteCKAN(portal_url)
+    return ckan_portal.call_action('organization_show',
+                                   data_dict={'id': org_id})
 
 
 def push_organization_tree_to_ckan(portal_url, apikey, org_tree, parent=None):

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -501,10 +501,15 @@ class OrganizationsTestCase(FederationSuite):
         for child in node['children']:
             self.check_hierarchy(child, parent=node['name'])
 
-    def test_get_organization_calls_api_correctly(self, mock_portal):
+    def test_get_organizations_calls_api_correctly(self, mock_portal):
         get_organizations_from_ckan(self.portal_url)
         mock_portal.return_value.call_action.assert_called_with(
             'group_tree', data_dict={'type': 'organization'})
+
+    def test_get_organization_calls_api_correctly(self, mock_portal):
+        get_organization_from_ckan(self.portal_url, 'test_id')
+        mock_portal.return_value.call_action.assert_called_with(
+            'organization_show', data_dict={'id': 'test_id'})
 
     def test_push_organizations_sends_correct_hierarchy(self, mock_portal):
         mock_portal.return_value.call_action = (lambda _, data_dict: data_dict)


### PR DESCRIPTION
Se creó la función 'get_organization_from_ckan' y su test correspondiente.
Se actualizó la documentación para incluir la existencia de dicha función.
Se corrigió la documentación que involucra a la función 'get_organizations_from_ckan'.

Closes #207.