### PR TITLE
206 push organization to ckan

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -461,6 +461,20 @@ parámetros:
   Retorna el árbol de organizaciones creadas. Cada nodo tiene un campo `success` que indica si fue creado exitosamente o
   no. En caso de que `success` sea False, los hijos de esa organización no son creados.
 
+- **pydatajson.federation.push_organization_to_ckan()**: Tomando en un diccionario la data de una organización; la crea
+en el portal de destino. Toma los siguientes parámetros:
+  - **portal_url**: La URL del portal CKAN de destino.
+  - **apikey**: La apikey de un usuario con los permisos que le permitan crear las organizaciones.
+  - **organization**: Diccionario con la información a crear, el único campo obligatorio es `name`. Para más
+  información sobre los campos posibles, ver la [documentación de CKAN](https://docs.ckan.org/en/latest/api/#ckan.logic.action.create.organization_create)
+  - **parent** (opcional, default: None): Si se define, la organización pasada en `organization` se crea bajo la
+  organización con `name` pasado en `parent`. Si no se pasa un parámetro, las organizaciones son creadas como primer
+  nivel.
+  
+  Retorna el diccionario de la organización creada. El resultado tiene un campo `success` que indica si fue creado
+  exitosamente o no.
+
+
 ## Anexo I: Estructura de respuestas
 
 ### validate_catalog()

--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -368,9 +368,9 @@ def push_organization_to_ckan(portal_url, apikey, organization, parent=None):
             apikey (str): La apikey de un usuario con los permisos que le
                 permitan crear la organización.
             organization(dict): Datos de la organización a crear.
-            parent(str): Campo name de la organizacion padre.
+            parent(str): Campo name de la organización padre.
         Returns:
-            (dict): Devuelve el la organizacion enviada,
+            (dict): Devuelve el diccionario de la organizacion enviada,
                 junto con el status detallando si la creación fue
                 exitosa o no.
 

--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -347,23 +347,41 @@ def push_organization_tree_to_ckan(portal_url, apikey, org_tree, parent=None):
                     exitosa o no.
 
     """
-    portal = RemoteCKAN(portal_url, apikey=apikey)
     created = []
     for node in org_tree:
-        if parent:
-            node['groups'] = [{'name': parent}]
-        try:
-            pushed_org = portal.call_action('organization_create',
-                                            data_dict=node)
-            pushed_org['success'] = True
-        except Exception as e:
-            logger.exception('Ocurrió un error creando la organización {}: {}'
-                             .format(node['title'], str(e)))
-            pushed_org = {'name': node, 'success': False}
-
+        pushed_org = push_organization_to_ckan(portal_url, apikey, node, parent=parent)
         if pushed_org['success']:
             pushed_org['children'] = push_organization_tree_to_ckan(
                 portal_url, apikey, node['children'], parent=node['name'])
 
         created.append(pushed_org)
     return created
+
+
+def push_organization_to_ckan(portal_url, apikey, organization, parent=None):
+    """Toma una organización y la crea en el portal de destino.
+        Args:
+            portal_url (str): La URL del portal CKAN de destino.
+            apikey (str): La apikey de un usuario con los permisos que le
+                permitan crear la organización.
+            organization(dict): Datos de la organización a crear.
+            parent(str): Campo name de la organizacion padre.
+        Returns:
+            (dict): Devuelve el la organizacion enviada,
+                junto con el status detallando si la creación fue
+                exitosa o no.
+
+    """
+    portal = RemoteCKAN(portal_url, apikey=apikey)
+    if parent:
+        organization['groups'] = [{'name': parent}]
+    try:
+        pushed_org = portal.call_action('organization_create',
+                                        data_dict=organization)
+        pushed_org['success'] = True
+    except Exception as e:
+        logger.exception('Ocurrió un error creando la organización {}: {}'
+                         .format(organization['title'], str(e)))
+        pushed_org = {'name': organization, 'success': False}
+
+    return pushed_org

--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -349,7 +349,10 @@ def push_organization_tree_to_ckan(portal_url, apikey, org_tree, parent=None):
     """
     created = []
     for node in org_tree:
-        pushed_org = push_organization_to_ckan(portal_url, apikey, node, parent=parent)
+        pushed_org = push_organization_to_ckan(portal_url,
+                                               apikey,
+                                               node,
+                                               parent=parent)
         if pushed_org['success']:
             pushed_org['children'] = push_organization_tree_to_ckan(
                 portal_url, apikey, node['children'], parent=node['name'])

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -512,7 +512,8 @@ class OrganizationsTestCase(FederationSuite):
         mock_portal.return_value.call_action.assert_called_with(
             'organization_show', data_dict={'id': 'test_id'})
 
-    def test_push_organization_sets_correct_attributes_on_success(self, mock_portal):
+    def test_push_organization_sets_correct_attributes_on_success(
+            self, mock_portal):
         mock_portal.return_value.call_action = (lambda _, data_dict: data_dict)
         pushed_org = push_organization_to_ckan(self.portal_url,
                                                self.apikey,
@@ -528,7 +529,8 @@ class OrganizationsTestCase(FederationSuite):
         self.assertEqual(1, len(pushed_org['groups']))
         self.assertDictEqual(pushed_org['groups'][0], {'name': 'parent'})
 
-    def test_push_organization_sets_correct_attributes_on_failures(self, mock_portal):
+    def test_push_organization_sets_correct_attributes_on_failures(
+            self, mock_portal):
         def broken_call(_, __):
             raise Exception('broken api call')
         mock_portal.return_value.call_action = broken_call


### PR DESCRIPTION
Closes #206 
- Extrae la funcionalidad para crear una organización en `push_organization_to_ckan()`
- Agrega tests de comportamiento
- Agrega documentación