### PR TITLE
218 remove organization from ckan

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -483,6 +483,16 @@ en el portal de destino. Toma los siguientes parámetros:
   Retorna el diccionario de la organización creada. El resultado tiene un campo `success` que indica si fue creado
   exitosamente o no.
 
+- **pydatajson.federation.remove_organization_from_ckan()**: Tomando el id o name de una organización; la borra en el
+portal de destino. Toma los siguientes parámetros:
+  - **portal_url**: La URL del portal CKAN de destino.
+  - **apikey**: La apikey de un usuario con los permisos que le permitan borrar la organización.
+  - **organization_id**: Id o name de la organización a borrar.
+    
+  Retorna None.
+  
+  **Advertencia**: En caso de que la organización tenga hijos en la jerarquía, estos pasan a ser de primer nivel.
+
 
 ## Anexo I: Estructura de respuestas
 

--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -417,3 +417,24 @@ def push_organization_to_ckan(portal_url, apikey, organization, parent=None):
         pushed_org = {'name': organization, 'success': False}
 
     return pushed_org
+
+
+def remove_organization_from_ckan(portal_url, apikey, organization_id):
+    """Toma un id de organización y la purga del portal de destino.
+        Args:
+            portal_url (str): La URL del portal CKAN de destino.
+            apikey (str): La apikey de un usuario con los permisos que le
+                permitan borrar la organización.
+            organization_id(str): Id o name de la organización a borrar.
+        Returns:
+            None.
+
+    """
+    portal = RemoteCKAN(portal_url, apikey=apikey)
+    try:
+        portal.call_action('organization_purge',
+                           data_dict={'id': organization_id})
+
+    except Exception as e:
+        logger.exception('Ocurrió un error borrando la organización {}: {}'
+                         .format(organization_id, str(e)))

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -586,3 +586,17 @@ class OrganizationsTestCase(FederationSuite):
                                                      self.org_tree)
         for node in pushed_tree:
             self.check_hierarchy(node)
+
+    def test_remove_organization_sends_correct_parameters(self, mock_portal):
+        remove_organization_from_ckan(self.portal_url, self.apikey, 'test_id')
+        mock_portal.return_value.call_action.assert_called_with(
+            'organization_purge', data_dict={'id': 'test_id'})
+
+    @patch('logging.Logger.exception')
+    def test_remove_organization_logs_failures(self, mock_logger, mock_portal):
+        mock_portal.return_value.call_action.side_effect = Exception('test')
+        remove_organization_from_ckan(self.portal_url, self.apikey, 'test_id')
+        mock_portal.return_value.call_action.assert_called_with(
+            'organization_purge', data_dict={'id': 'test_id'})
+        mock_logger.assert_called_with(
+            'Ocurrió un error borrando la organización test_id: test')


### PR DESCRIPTION
Closes #218 

- Agrega método `remove_organization_from_ckan()`.
- Agrega tests del comportamiento.
- Agrega documentación del método.