### PR TITLE
222 regenerar accessurl

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -353,7 +353,10 @@ Toma los siguientes parámetros:
   - **download_strategy** (opcional, default None): La referencia a una función que toma (catalog, distribution) de
   entrada y devuelve un booleano. Esta función se aplica sobre todas las distribuciones del dataset. Si devuelve `True`,
   se descarga el archivo indicado en el `downloadURL` de la distribución y se lo sube al portal de destino. Si es None,
-  se omite esta operación. 
+  se omite esta operación.
+  - **generate_new_access_url** (opcional, default None): Se pasan los ids de las distribuciones cuyo accessURL se regenerar en el portal de
+      destino. Para el resto, el portal debe mantiene el valor pasado en el DataJson.
+ 
 
 
   Retorna el id en el nodo de destino del dataset federado.
@@ -423,6 +426,9 @@ Toma los siguientes parámetros:
   entrada y devuelve un booleano. Esta función se aplica sobre todas las distribuciones del dataset. Si devuelve `True`,
   se descarga el archivo indicado en el `downloadURL` de la distribución y se lo sube al portal de destino. Si es None,
   se omite esta operación.
+  - **generate_new_access_url** (opcional, default None): Se pasan los ids de las distribuciones cuyo accessURL se regenerar en el portal de
+      destino. Para el resto, el portal debe mantiene el valor pasado en el DataJson.
+
 
   Retorna el id del dataset restaurado.
 
@@ -453,6 +459,8 @@ parámetro. Toma los siguientes parámetros:
     - **owner_org**: La organización a la cual pertencen los datasets.
     - **download_strategy**: Una función (catálogo, distribución)->bool. Sobre las distribuciones que evalúa True,
         descarga el recurso en el downloadURL y lo sube al portal de destino. Por default no sube ninguna distribución.
+    - **generate_new_access_url** (opcional, default None): Se pasan los ids de las distribuciones cuyo accessURL se regenerar en el portal de
+        destino. Para el resto, el portal debe mantiene el valor pasado en el DataJson.
         
     Retorna la lista de ids de datasets subidos.
 
@@ -463,15 +471,23 @@ Toma los siguientes parámetros:
   - **destination_portal_url**: La URL del portal CKAN de destino.
   - **apikey**: La apikey de un usuario con los permisos que le permitan crear o actualizar los dataset.
   - **download_strategy**: Una función (catálogo, distribución)-> bool. Sobre las distribuciones que evalúa True,
-    descarga el recurso en el downloadURL y lo sube al portal de destino. Por default no sube ninguna distribución.
+      descarga el recurso en el downloadURL y lo sube al portal de destino. Por default no sube ninguna distribución.
+  - **generate_new_access_url** (opcional, default None): Se pasan los ids de las distribuciones cuyo accessURL se regenerar en el portal de
+      destino. Para el resto, el portal debe mantiene el valor pasado en el DataJson.
 
   Retorna un diccionario con key organización y value la lista de ids de datasets subidos a esa organización
 
-- **pydatajson.federation.resources_update()**: Sube archivos de recursos a las distribuciones indicadas.
-Toma los siguientes parámetros:
+- **pydatajson.federation.resources_update()**: Sube archivos de recursos a las distribuciones indicadas y regenera los
+accessURL en las distribuciones indicadas. Toma los siguientes parámetros:
   - **portal_url**: URL del portal de CKAN de destino.
   - **apikey**: La apikey de un usuario del portal de destino con los permisos para modificar la distribución.
+  - **distributions**: Lista de distribuciones posibles para actualizar.
   - **resource_files** Diccionario con el id de las distribuciones y un path al recurso correspondiente a subir.
+  - **generate_new_access_url** (opcional, default None): Lista de ids de distribuciones a las cuales se actualizará el
+    accessURL con los valores generados por el portal de destino.
+  - **catalog_id** (opcional, default None): prependea el id al id del recurso para encontrarlo antes de subirlo si es
+    necesario.
+      
   
   Retorna una lista con los ids de las distribuciones modificadas exitosamente.
   

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -444,7 +444,30 @@ Toma los siguientes parámetros:
 
   Retorna el id en el nodo de destino de los datasets federados.
   
-- **pydatajson.federation.resources_upload()**: Sube archivos de recursos a las distribuciones indicadas.
+- **pydatajson.DataJson.restore_organization_to_ckan()**: Restaura los datasets de una organización al portal pasado por
+parámetro. Toma los siguientes parámetros:
+    - **catalog**: El catálogo de origen que se restaura.
+    - **portal_url**: La URL del portal CKAN de destino.
+    - **apikey**: La apikey de un usuario con los permisos que le permitan crear o actualizar los dataset.
+    - **dataset_list**: Los ids de los datasets a restaurar. Si no se pasa una lista, todos los datasests se restauran.
+    - **owner_org**: La organización a la cual pertencen los datasets.
+    - **download_strategy**: Una función (catálogo, distribución)->bool. Sobre las distribuciones que evalúa True,
+        descarga el recurso en el downloadURL y lo sube al portal de destino. Por default no sube ninguna distribución.
+        
+    Retorna la lista de ids de datasets subidos.
+
+- **pydatajson.DataJson.restore_catalog_to_ckan()**: Restaura los datasets de un catálogo al portal pasado por parámetro.
+Toma los siguientes parámetros:
+  - **catalog**: El catálogo de origen que se restaura.
+  - **origin_portal_url**: La URL del portal CKAN de origen.
+  - **destination_portal_url**: La URL del portal CKAN de destino.
+  - **apikey**: La apikey de un usuario con los permisos que le permitan crear o actualizar los dataset.
+  - **download_strategy**: Una función (catálogo, distribución)-> bool. Sobre las distribuciones que evalúa True,
+    descarga el recurso en el downloadURL y lo sube al portal de destino. Por default no sube ninguna distribución.
+
+  Retorna un diccionario con key organización y value la lista de ids de datasets subidos a esa organización
+
+- **pydatajson.federation.resources_update()**: Sube archivos de recursos a las distribuciones indicadas.
 Toma los siguientes parámetros:
   - **portal_url**: URL del portal de CKAN de destino.
   - **apikey**: La apikey de un usuario del portal de destino con los permisos para modificar la distribución.
@@ -452,7 +475,7 @@ Toma los siguientes parámetros:
   
   Retorna una lista con los ids de las distribuciones modificadas exitosamente.
   
-  **Advertencia**: La función `resources_upload()` cambia el `resource_type` de las distribuciones a `file.upload`.
+  **Advertencia**: La función `resources_update()` cambia el `resource_type` de las distribuciones a `file.upload`.
   
 ### Métodos para manejo de organizaciones
 

--- a/pydatajson/ckan_utils.py
+++ b/pydatajson/ckan_utils.py
@@ -167,3 +167,36 @@ def map_theme_to_group(theme):
         "title": theme.get('label'),
         "description": theme.get('description'),
     }
+
+
+def theme_cataclysm(portal):
+    themes = portal.action.group_list()
+    for theme in themes:
+        try:
+            portal.action.group_purge(id=theme)
+        except:
+            continue
+
+
+def dataset_extintion(portal):
+    datasets = portal.action.package_list()
+    for dataset in datasets:
+        try:
+            portal.action.dataset_purge(id=dataset)
+        except:
+            continue
+
+
+def organization_inquisition(portal):
+    organzations = portal.action.organization_list()
+    for organization in organzations:
+        try:
+            portal.action.organization_purge(id=organization)
+        except:
+            continue
+
+
+def nuke_from_orbit(portal):
+    dataset_extintion(portal)
+    theme_cataclysm(portal)
+    organization_inquisition(portal)

--- a/pydatajson/ckan_utils.py
+++ b/pydatajson/ckan_utils.py
@@ -167,36 +167,3 @@ def map_theme_to_group(theme):
         "title": theme.get('label'),
         "description": theme.get('description'),
     }
-
-
-def theme_cataclysm(portal):
-    themes = portal.action.group_list()
-    for theme in themes:
-        try:
-            portal.action.group_purge(id=theme)
-        except:
-            continue
-
-
-def dataset_extintion(portal):
-    datasets = portal.action.package_list()
-    for dataset in datasets:
-        try:
-            portal.action.dataset_purge(id=dataset)
-        except:
-            continue
-
-
-def organization_inquisition(portal):
-    organzations = portal.action.organization_list()
-    for organization in organzations:
-        try:
-            portal.action.organization_purge(id=organization)
-        except:
-            continue
-
-
-def nuke_from_orbit(portal):
-    dataset_extintion(portal)
-    theme_cataclysm(portal)
-    organization_inquisition(portal)

--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -93,8 +93,13 @@ def resources_update(portal_url, apikey, distributions,
                 portal_url (str): La URL del portal CKAN de destino.
                 apikey (str): La apikey de un usuario con los permisos que le
                     permitan crear o actualizar el dataset.
+                distributions(list): Lista de distribuciones posibles para
+                    actualizar.
                 resource_files(dict): Diccionario con entradas
                     id_de_distribucion:path_al_recurso a subir
+                generate_new_access_url(list): Lista de ids de distribuciones a
+                    las cuales se actualizará el accessURL con los valores
+                    generados por el portal de destino
                 catalog_id(str): prependea el id al id del recurso para
                     encontrarlo antes de subirlo
             Returns:
@@ -248,6 +253,10 @@ def restore_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier,
                 bool. Sobre las distribuciones que evalúa True, descarga el
                 recurso en el downloadURL y lo sube al portal de destino.
                 Por default no sube ninguna distribución.
+            generate_new_access_url(list): Se pasan los ids de las
+                    distribuciones cuyo accessURL se regenerar en el portal de
+                    destino. Para el resto, el portal debe mantiene el valor
+                    pasado en el DataJson.
         Returns:
             str: El id del dataset restaurado.
     """
@@ -489,6 +498,10 @@ def restore_organization_to_ckan(catalog, owner_org, portal_url, apikey,
                 bool. Sobre las distribuciones que evalúa True, descarga el
                 recurso en el downloadURL y lo sube al portal de destino.
                 Por default no sube ninguna distribución.
+            generate_new_access_url(list): Se pasan los ids de las
+                    distribuciones cuyo accessURL se regenerar en el portal de
+                    destino. Para el resto, el portal debe mantiene el valor
+                    pasado en el DataJson.
         Returns:
             list(str): La lista de ids de datasets subidos.
     """
@@ -533,6 +546,10 @@ def restore_catalog_to_ckan(catalog, origin_portal_url, destination_portal_url,
                     que evalúa True, descarga el recurso en el downloadURL y lo
                     sube al portal de destino. Por default no sube ninguna
                     distribución.
+                generate_new_access_url(list): Se pasan los ids de las
+                    distribuciones cuyo accessURL se regenerar en el portal de
+                    destino. Para el resto, el portal debe mantiene el valor
+                    pasado en el DataJson.
             Returns:
                 dict: Diccionario con key organización y value la lista de ids
                     de datasets subidos a esa organización

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -374,7 +374,8 @@ class PushDatasetTestCase(FederationSuite):
             self.assertEqual('', kwargs['accessURL'])
             return {'id': kwargs['id']}
 
-        mock_portal.return_value.action.resource_patch.side_effect = side_effect
+        mock_portal.return_value.action.resource_patch.side_effect =\
+            side_effect
 
         pushed = push_dataset_to_ckan(self.catalog, 'owner',
                                       self.dataset_id,
@@ -394,7 +395,8 @@ class PushDatasetTestCase(FederationSuite):
         def side_effect(**kwargs):
             self.fail('should not be called')
 
-        mock_portal.return_value.action.resource_patch.side_effect = side_effect
+        mock_portal.return_value.action.resource_patch.side_effect =\
+            side_effect
 
         pushed = push_dataset_to_ckan(self.catalog, 'owner',
                                       self.dataset_id,

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -298,7 +298,7 @@ class PushDatasetTestCase(FederationSuite):
             return_value={'id': 'an_id',
                           'resource_type': 'file.upload'})
         resources = {'an_id': 'tests/samples/resource_sample.csv'}
-        res = resources_upload('portal', 'key', resources)
+        res = resources_update('portal', 'key', resources)
         mock_portal.return_value.action.resource_patch.assert_called_with(
             id='an_id',
             resource_type='file.upload',
@@ -310,7 +310,7 @@ class PushDatasetTestCase(FederationSuite):
         mock_portal.return_value.action.resource_patch = MagicMock(
             side_effect=Exception('broken resource'))
         resources = {'an_id': 'tests/samples/resource_sample.csv'}
-        res = resources_upload('portal', 'key', resources)
+        res = resources_update('portal', 'key', resources)
         mock_portal.return_value.action.resource_patch.assert_called_with(
             id='an_id',
             resource_type='file.upload',


### PR DESCRIPTION
- Agrega un nuevo parámetro opcional a `push_dataset_to_ckan()`. `generate_access_url`, toma una lista de identificadores de distribuciones. Las distribuciones de esa lista regeneran el campo `accessURL` de acuerdo al portal de destino. Las que no están en esa lista, mantienen el campo (el comportamiento anterior).
- Agrega tests del nuevo parámetro y modifica los existentes para adptarlo.
- Agrega documentación.