### PR TITLE
88 extension lectura json

### DIFF
--- a/pydatajson/custom_exceptions.py
+++ b/pydatajson/custom_exceptions.py
@@ -128,6 +128,13 @@ class DistributionUnexpectedTitle(BaseUnexpectedValue):
         super(DistributionUnexpectedTitle, self).__init__(msg)
 
 
+class NonParseableCatalog(ValueError):
+    """No se puede leer un data.json a partir del parámetro pasado"""
+    def __init__(self, catalog, error):
+        msg = "Error parseando el datajson {}: {}".format(catalog, error)
+        super(NonParseableCatalog, self).__init__(msg)
+
+
 class BaseRepetitionError(ValueError):
 
     """El id de una entidad está repetido en el catálogo."""

--- a/pydatajson/readers.py
+++ b/pydatajson/readers.py
@@ -38,6 +38,7 @@ openpyxl_exceptions = (CellCoordinatesException, IllegalCharacterError,
                        InsufficientCoordinatesException, InvalidFileException,
                        ReadOnlyWorkbookException, WorkbookAlreadySaved)
 
+
 def read_catalog_obj(catalog):
     try:
         if getattr(catalog, "has_catalog"):
@@ -81,12 +82,12 @@ def read_catalog(catalog, default_values=None):
         if suffix == "xlsx":
             try:
                 catalog_dict = read_xlsx_catalog(catalog)
-            except openpyxl_exceptions as e:
+            except openpyxl_exceptions + (ValueError,) as e:
                 raise ce.NonParseableCatalog(catalog, str(e))
         else:
             try:
                 catalog_dict = read_json(catalog)
-            except(ValueError, TypeError) as e:
+            except(ValueError, TypeError, IOError) as e:
                 raise ce.NonParseableCatalog(catalog, str(e))
 
     # si se pasaron valores default, los aplica al catálogo leído

--- a/tests/samples/full_data
+++ b/tests/samples/full_data
@@ -1,0 +1,226 @@
+{
+    "publisher": {
+        "mbox": "datos@modernizacion.gob.ar",
+        "name": "Ministerio de Modernización"
+    },
+    "license": "Open Data Commons Open Database License 1.0",
+    "description": "Portal de Datos Abiertos del Gobierno de la República Argentina",
+    "language": [
+        "spa"
+    ],
+    "title": "Datos Argentina",
+    "issued": "2016-04-14T19:48:05.433640-03:00",
+    "rights": "Derechos especificados en la licencia.",
+    "modified": "2016-04-19T19:48:05.433640-03:00",
+    "dataset": [
+        {
+            "publisher": {
+                "mbox": "onc@modernizacion.gob.ar",
+                "name": "Ministerio de Modernización. Secretaría de Modernización Administrativa. Oficina Nacional de Contrataciones"
+            },
+            "license": "Open Data Commons Open Database License 1.0",
+            "description": "Datos correspondientes al Sistema de Contrataciones Electrónicas (Argentina Compra)",
+            "superTheme": [
+                "econ"
+            ],
+            "title": "Sistema de contrataciones electrónicas",
+            "issued": "2016-04-14T19:48:05.433640-03:00",
+            "temporal": "2015-01-01/2015-12-31",
+            "modified": "2016-04-19T19:48:05.433640-03:00",
+            "language": [
+                "spa"
+            ],
+            "theme": [
+                "contrataciones",
+                "compras",
+                "convocatorias"
+            ],
+            "keyword": [
+                "bienes",
+                "compras",
+                "contrataciones",
+                "bienes y compras"
+            ],
+            "accrualPeriodicity": "R/P1Y",
+            "spatial": "ARG",
+            "identifier": "99db6631-d1c9-470b-a73e-c62daa32c777",
+            "contactPoint": {
+                "hasEmail": "onc-compraselectronicas@modernizacion.gob.ar",
+                "fn": "Ministerio de Modernización. Secretaría de Modernización Administrativa. Oficina Nacional de Contrataciones. Dirección de Compras Electrónicas."
+            },
+            "landingPage": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra",
+            "distribution": [
+                {
+                    "accessURL": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra/archivo/fa3603b3-0af7-43cc-9da9-90a512217d8a",
+                    "identifier": "1.1",
+                    "description": "Listado de las convocatorias abiertas durante el año 2015 en el sistema de contrataciones electrónicas",
+                    "license": "Open Data Commons Open Database License 1.0",
+                    "title": "Convocatorias abiertas durante el año 2015",
+                    "dataset_identifier": "99db6631-d1c9-470b-a73e-c62daa32c777",
+                    "byteSize": 5120,
+                    "type": "file",
+                    "format": "CSV",
+                    "rights": "Derechos especificados en la licencia.",
+                    "mediaType": "text/csv",
+                    "modified": "2016-04-19T19:48:05.433640-03:00",
+                    "downloadURL": "http://186.33.211.253/dataset/99db6631-d1c9-470b-a73e-c62daa32c420/resource/4b7447cb-31ff-4352-96c3-589d212e1cc9/download/convocatorias-abiertas-anio-2015.csv",
+                    "field": [
+                        {
+                            "title": "procedimiento_id",
+                            "type": "integer",
+                            "id": "proc12",
+                            "description": "Identificador único del procedimiento de contratación"
+                        },
+                        {
+                            "type": "integer",
+                            "description": "Identificador único del organismo que realiza la convocatoria. Organismo de máximo nivel jerárquico al que pertenece la unidad operativa de contrataciones.",
+                            "title": "organismo_unidad_operativa_contrataciones_id"
+                        },
+                        {
+                            "type": "integer",
+                            "description": "Identificador único de la unidad operativa de contrataciones",
+                            "title": "unidad_operativa_contrataciones_id"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Organismo que realiza la convocatoria. Organismo de máximo nivel jerárquico al que pertenece la unidad operativa de contrataciones.",
+                            "title": "organismo_unidad_operativa_contrataciones_desc"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Unidad operativa de contrataciones.",
+                            "title": "unidad_operativa_contrataciones_desc"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Tipo de procedimiento al que se adecua la contratación.",
+                            "title": "tipo_procedimiento_contratacion"
+                        },
+                        {
+                            "type": "date",
+                            "description": "Año en el que se inició el proceso de la convocatoria.",
+                            "title": "ejercicio_procedimiento_anio"
+                        },
+                        {
+                            "type": "date",
+                            "description": "Fecha de publicación de la convocatoria en formato AAAA-MM-DD, ISO 8601.",
+                            "title": "fecha_publicacion_convocatoria"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Modalidad bajo la cual se realiza la convocatoria.",
+                            "title": "modalidad_convocatoria"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Clase de la convocatoria.",
+                            "title": "clase_convocatoria"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Objeto/objetivo de la convocatoria",
+                            "title": "objeto_convocatoria"
+                        }
+                    ],
+                    "issued": "2016-04-14T19:48:05.433640-03:00",
+                    "fileName": "convocatoriasabiertasduranteelao.csv"
+                }
+            ],
+            "source": "Ministerio de modernizacion"
+        },
+        {
+            "publisher": {
+                "mbox": "onc@modernizacion.gob.ar",
+                "name": "Ministerio de Modernización. Secretaría de Modernización Administrativa. Oficina Nacional de Contrataciones"
+            },
+            "license": "Open Data Commons Open Database License 1.0",
+            "description": "Datos correspondientes al Sistema de Contrataciones Electrónicas (Argentina Compra) (sin datos)",
+            "superTheme": [
+                "ECON"
+            ],
+            "title": "Sistema de contrataciones electrónicas (sin datos)",
+            "issued": "2016-04-14T19:48:05.433640-03:00",
+            "temporal": "2015-01-01/2015-12-31",
+            "modified": "2016-04-19T19:48:05.433640-03:00",
+            "language": [
+                "spa"
+            ],
+            "theme": [
+                "contrataciones",
+                "compras",
+                "convocatorias"
+            ],
+            "keyword": [
+                "bienes",
+                "compras",
+                "contrataciones",
+                "bienes y compras"
+            ],
+            "accrualPeriodicity": "R/P1Y",
+            "spatial": "ARG",
+            "identifier": "99db6631-d1c9-470b-a73e-c62daa32c420",
+            "contactPoint": {
+                "hasEmail": "onc-compraselectronicas@modernizacion.gob.ar",
+                "fn": "Ministerio de Modernización. Secretaría de Modernización Administrativa. Oficina Nacional de Contrataciones. Dirección de Compras Electrónicas."
+            },
+            "landingPage": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra",
+            "distribution": [
+                {
+                    "accessURL": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra/archivo/fa3603b3-0af7-43cc-9da9-90a512217d8a",
+                    "identifier": "d_7d4d816f-3a40-476e-ab71-d48a3f0eb3c8",
+                    "description": "Listado de las convocatorias abiertas durante el año 2015 en el sistema de contrataciones electrónicas",
+                    "license": "Open Data Commons Open Database License 1.0",
+                    "title": "Convocatorias abiertas durante el año 2015",
+                    "dataset_identifier": "99db6631-d1c9-470b-a73e-c62daa32c420",
+                    "byteSize": 5120,
+                    "type": "documentation",
+                    "format": "PDF",
+                    "rights": "Derechos especificados en la licencia.",
+                    "mediaType": "application/pdf",
+                    "modified": "2016-04-19T19:48:05.433640-03:00",
+                    "downloadURL": "http://186.33.211.253/dataset/99db6631-d1c9-470b-a73e-c62daa32c420/resource/4b7447cb-31ff-4352-96c3-589d212e1cc9/download/convocatorias-abiertas-anio-2015.pdf",
+                    "issued": "2016-04-14T19:48:05.433640-03:00",
+                    "fileName": "convocatoriasabiertasduranteelao.pdf"
+                }
+            ],
+            "source": "Ministerio de modernizacion"
+        }
+    ],
+    "identifier": "7d4d816f-3a40-476e-ab71-d48a3f0eb3c8",
+    "version": "1.1",
+    "spatial": "ARG",
+    "superThemeTaxonomy": "http://datos.gob.ar/superThemeTaxonomy.json",
+    "themeTaxonomy": [
+        {
+            "label": "Convocatorias",
+            "description": "Datasets sobre licitaciones en estado de convocatoria.",
+            "id": "convocatorias"
+        },
+        {
+            "label": "Adquisición",
+            "description": "Datasets sobre compras realizadas.",
+            "id": "compras"
+        },
+        {
+            "label": "Contrataciones",
+            "description": "Datasets sobre contrataciones.",
+            "id": "contrataciones"
+        },
+        {
+            "label": "Adjudicaciones",
+            "description": "Datasets sobre licitaciones adjudicadas.",
+            "id": "adjudicaciones"
+        },
+        {
+            "label": "Normativa",
+            "description": "Datasets sobre normativa para compras y contrataciones.",
+            "id": "normativa"
+        },
+        {
+            "label": "Proveeduría",
+            "description": "Datasets sobre proveedores del Estado.",
+            "id": "proveedores"
+        }
+    ],
+    "homepage": "http://datos.gob.ar"
+}

--- a/tests/test_readers_and_writers.py
+++ b/tests/test_readers_and_writers.py
@@ -21,6 +21,7 @@ except ImportError:
 import filecmp
 from .context import pydatajson
 from pydatajson.helpers import ensure_dir_exists
+from pydatajson.custom_exceptions import NonParseableCatalog
 from . import xl_methods
 import openpyxl as pyxl
 
@@ -169,7 +170,7 @@ revíselo manualmente""".format(temp_filename)
 
         try:
             pydatajson.readers.read_xlsx_catalog(tmp_xlsx)
-        except BaseException:
+        except NonParseableCatalog:
             self.fail("No se pudo leer archivo XLSX")
 
     def test_read_local_xlsx_catalog_with_defaults(self):
@@ -263,6 +264,17 @@ revíselo manualmente""".format(temp_filename)
                 self.assertTrue(dataset[field])
                 # Elementos no vacios
                 self.assertTrue(all(dataset[field]))
+
+    def test_read_without_suffix_reads_json(self):
+        original = pydatajson.readers.read_catalog(
+            self.get_sample('full_data.json'))
+        suffixless = pydatajson.readers.read_catalog(
+            self.get_sample('full_data'))
+        self.assertDictEqual(original, suffixless)
+
+    @nose.tools.raises(NonParseableCatalog)
+    def test_failing_catalog_raises_non_parseable_error(self):
+        pydatajson.readers.read_catalog('inexistent_file')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Closes datosgobar/django-datajsonar#88

- Ante ausencia de sufijo, el lector de DataJson asume que el formato es JSON
- Cambia la excepción que lanza en caso de no poder parsear, para fallar de manera más controlada
- Agrega tests del comportamiento