### PR TITLE
Agrego parámetro validator_class

### DIFF
--- a/pydatajson/core.py
+++ b/pydatajson/core.py
@@ -51,7 +51,8 @@ class DataJson(dict):
     CATALOG_FIELDS_PATH = os.path.join(ABSOLUTE_PROJECT_DIR, "fields")
 
     def __init__(self, catalog=None, schema_filename=None, schema_dir=None,
-                 default_values=None, catalog_format=None):
+                 default_values=None, catalog_format=None,
+                 validator_class=None):
         """Lee un catálogo y crea un objeto con funciones para manipularlo.
 
         Salvo que se indique lo contrario, se utiliza como default el schema
@@ -97,7 +98,7 @@ class DataJson(dict):
             self.has_catalog = False
 
         self.validator = validation.create_validator(
-            schema_filename, schema_dir)
+            schema_filename, schema_dir, validator_class)
 
         # asigno docstrings de los métodos modularizados
         fn_doc = indicators.generate_catalogs_indicators.__doc__

--- a/pydatajson/validation.py
+++ b/pydatajson/validation.py
@@ -37,7 +37,9 @@ EXTENSIONS_EXCEPTIONS = ["zip", "php", "asp", "aspx"]
 logger = logging.getLogger('pydatajson')
 
 
-def create_validator(schema_filename=None, schema_dir=None):
+def create_validator(schema_filename=None,
+                     schema_dir=None,
+                     validator_class=None):
     """Crea el validador necesario para inicializar un objeto DataJson.
 
     Para poder resolver referencias inter-esquemas, un Validador requiere
@@ -64,6 +66,7 @@ def create_validator(schema_filename=None, schema_dir=None):
     schema_dir = schema_dir or ABSOLUTE_SCHEMA_DIR
     schema_path = os.path.join(schema_dir, schema_filename)
     schema = readers.read_json(schema_path)
+    validator_class = validator_class or jsonschema.Draft4Validator
 
     # Según https://github.com/Julian/jsonschema/issues/98
     # Permite resolver referencias locales a otros esquemas.
@@ -75,7 +78,7 @@ def create_validator(schema_filename=None, schema_dir=None):
 
     format_checker = jsonschema.FormatChecker()
 
-    validator = jsonschema.Draft4Validator(
+    validator = validator_class(
         schema=schema, resolver=resolver, format_checker=format_checker)
 
     return validator


### PR DESCRIPTION
Permite extender la funcionalidad de validación de catálogos. La clase
deberá implementar los métodos is_valid, que devuelve True o False según
el catálogo sea válido, e iter_errors, un generator de errores. La forma
más sencilla de cumplir los requerimientos es que el validador sea una
instancia de jsonschema.Draft4Validator, o de una clase que herede de
ésta.