### PR TITLE
Agrego parametros de timeout y verficación de ssl

### DIFF
--- a/pydatajson/ckan_utils.py
+++ b/pydatajson/ckan_utils.py
@@ -6,9 +6,12 @@ import json
 import re
 import logging
 from datetime import time
+
+from ckanapi import RemoteCKAN
 from dateutil import parser, tz
 from .helpers import title_to_name
 from . import custom_exceptions as ce
+from .constants import REQUESTS_TIMEOUT
 
 logger = logging.getLogger('pydatajson')
 
@@ -167,3 +170,21 @@ def map_theme_to_group(theme):
         "title": theme.get('label'),
         "description": theme.get('description'),
     }
+
+
+class CustomRemoteCKAN(RemoteCKAN):
+
+    def __init__(self, address, apikey=None, user_agent=None, get_only=False,
+                 verify_ssl=False, requests_timeout=REQUESTS_TIMEOUT):
+        self.verify_ssl = verify_ssl
+        self.requests_timeout = requests_timeout
+        super(CustomRemoteCKAN, self).__init__(address, apikey,
+                                               user_agent, get_only)
+
+    def call_action(self, action, data_dict=None, context=None, apikey=None,
+                    files=None, requests_kwargs=None):
+        requests_kwargs = requests_kwargs or {}
+        requests_kwargs.setdefault('verify', self.verify_ssl)
+        requests_kwargs.setdefault('timeout', self.requests_timeout)
+        return super(CustomRemoteCKAN, self).call_action(
+            action, data_dict, context, apikey, files, requests_kwargs)

--- a/pydatajson/ckan_utils.py
+++ b/pydatajson/ckan_utils.py
@@ -7,11 +7,9 @@ import re
 import logging
 from datetime import time
 
-from ckanapi import RemoteCKAN
 from dateutil import parser, tz
 from .helpers import title_to_name
 from . import custom_exceptions as ce
-from .constants import REQUESTS_TIMEOUT
 
 logger = logging.getLogger('pydatajson')
 
@@ -170,21 +168,3 @@ def map_theme_to_group(theme):
         "title": theme.get('label'),
         "description": theme.get('description'),
     }
-
-
-class CustomRemoteCKAN(RemoteCKAN):
-
-    def __init__(self, address, apikey=None, user_agent=None, get_only=False,
-                 verify_ssl=False, requests_timeout=REQUESTS_TIMEOUT):
-        self.verify_ssl = verify_ssl
-        self.requests_timeout = requests_timeout
-        super(CustomRemoteCKAN, self).__init__(address, apikey,
-                                               user_agent, get_only)
-
-    def call_action(self, action, data_dict=None, context=None, apikey=None,
-                    files=None, requests_kwargs=None):
-        requests_kwargs = requests_kwargs or {}
-        requests_kwargs.setdefault('verify', self.verify_ssl)
-        requests_kwargs.setdefault('timeout', self.requests_timeout)
-        return super(CustomRemoteCKAN, self).call_action(
-            action, data_dict, context, apikey, files, requests_kwargs)

--- a/pydatajson/custom_remote_ckan.py
+++ b/pydatajson/custom_remote_ckan.py
@@ -1,0 +1,21 @@
+from ckanapi import RemoteCKAN
+
+from pydatajson.constants import REQUESTS_TIMEOUT
+
+
+class CustomRemoteCKAN(RemoteCKAN):
+
+    def __init__(self, address, apikey=None, user_agent=None, get_only=False,
+                 verify_ssl=False, requests_timeout=REQUESTS_TIMEOUT):
+        self.verify_ssl = verify_ssl
+        self.requests_timeout = requests_timeout
+        super(CustomRemoteCKAN, self).__init__(address, apikey,
+                                               user_agent, get_only)
+
+    def call_action(self, action, data_dict=None, context=None, apikey=None,
+                    files=None, requests_kwargs=None):
+        requests_kwargs = requests_kwargs or {}
+        requests_kwargs.setdefault('verify', self.verify_ssl)
+        requests_kwargs.setdefault('timeout', self.requests_timeout)
+        return super(CustomRemoteCKAN, self).call_action(
+            action, data_dict, context, apikey, files, requests_kwargs)

--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -10,7 +10,7 @@ from ckanapi.errors import NotFound, CKANAPIError
 
 from pydatajson.constants import REQUESTS_TIMEOUT
 from .ckan_utils import map_dataset_to_package, map_theme_to_group
-from .ckan_utils import CustomRemoteCKAN as RemoteCKAN
+from pydatajson.custom_remote_ckan import CustomRemoteCKAN as RemoteCKAN
 from .search import get_datasets
 from .helpers import resource_files_download
 


### PR DESCRIPTION
Closes #235 

- Los métodos que toman un catálogo DataJson usan el `requests_timeout` y `verify_ssl`
- Si no toman un catálogo, se le pueden pasar esos parámetros por kwargs