### PR TITLE
262 validar ids recursos federables no puramente numericos

### DIFF
--- a/pydatajson/custom_exceptions.py
+++ b/pydatajson/custom_exceptions.py
@@ -368,3 +368,8 @@ class DownloadURLBrokenError(BaseNonExistentError):
 
 class FormatNameError(ValueError):
     pass
+
+
+class NumericDistributionIdentifierError(ValueError):
+    """La distribucion tiene un id puramente numerico, lo cual imposibilita restaurar"""
+    pass

--- a/pydatajson/custom_exceptions.py
+++ b/pydatajson/custom_exceptions.py
@@ -371,5 +371,5 @@ class FormatNameError(ValueError):
 
 
 class NumericDistributionIdentifierError(ValueError):
-    """La distribucion tiene un id puramente numerico, lo cual imposibilita restaurar"""
+    """La distribucion tiene un id puramente numerico"""
     pass

--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -8,7 +8,9 @@ from __future__ import print_function, unicode_literals
 import logging
 from ckanapi.errors import NotFound, CKANAPIError
 
+from pydatajson import DataJson
 from pydatajson.constants import REQUESTS_TIMEOUT
+from pydatajson.custom_exceptions import NumericDistributionIdentifierError
 from .ckan_utils import map_dataset_to_package, map_theme_to_group
 from pydatajson.custom_remote_ckan import CustomRemoteCKAN as RemoteCKAN
 from .search import get_datasets
@@ -278,6 +280,19 @@ def restore_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier,
         Returns:
             str: El id del dataset restaurado.
     """
+
+    conditions = {
+        "dataset": {
+            "identifier": dataset_origin_identifier
+        }
+    }
+    distributions = DataJson().get_distributions(catalog=catalog, filter_in=conditions)
+
+    for distribution in distributions:
+        if distribution["identifier"].isdigit():
+            raise NumericDistributionIdentifierError(
+                'No puede restaurarse la distribucion con id "{}" dado que este es numerico. '
+                'Por favor, cambielo e intente de nuevo'.format(distribution["identifier"]))
 
     return push_dataset_to_ckan(catalog, owner_org,
                                 dataset_origin_identifier, portal_url,

--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -592,7 +592,8 @@ def restore_organization_to_ckan(catalog, owner_org, portal_url, apikey,
                                                   apikey, download_strategy,
                                                   generate_new_access_url)
             restored.append(restored_id)
-        except (CKANAPIError, KeyError, AttributeError) as e:
+        except (CKANAPIError, KeyError, AttributeError,
+                NumericDistributionIdentifierError) as e:
             logger.exception('Ocurrió un error restaurando el dataset {}: {}'
                              .format(dataset_id, str(e)))
     return restored

--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -8,7 +8,6 @@ from __future__ import print_function, unicode_literals
 import logging
 from ckanapi.errors import NotFound, CKANAPIError
 
-from pydatajson import DataJson
 from pydatajson.constants import REQUESTS_TIMEOUT
 from pydatajson.custom_exceptions import NumericDistributionIdentifierError
 from .ckan_utils import map_dataset_to_package, map_theme_to_group
@@ -286,13 +285,14 @@ def restore_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier,
             "identifier": dataset_origin_identifier
         }
     }
-    distributions = DataJson().get_distributions(catalog=catalog, filter_in=conditions)
+    distributions = catalog.get_distributions(filter_in=conditions)
 
     for distribution in distributions:
         if distribution["identifier"].isdigit():
             raise NumericDistributionIdentifierError(
-                'No puede restaurarse la distribucion con id "{}" dado que este es numerico. '
-                'Por favor, cambielo e intente de nuevo'.format(distribution["identifier"]))
+                'No puede restaurarse la distribucion con id "{}" dado que '
+                'este es numerico. Por favor, cambielo e intente de '
+                'nuevo'.format(distribution["identifier"]))
 
     return push_dataset_to_ckan(catalog, owner_org,
                                 dataset_origin_identifier, portal_url,

--- a/tests/samples/numeric_distribution_identifier.json
+++ b/tests/samples/numeric_distribution_identifier.json
@@ -1,0 +1,186 @@
+{
+    "publisher": {
+        "mbox": "datos@modernizacion.gob.ar",
+        "name": "Ministerio de Modernización"
+    },
+    "license": "Open Data Commons Open Database License 1.0",
+    "description": "Portal de Datos Abiertos del Gobierno de la República Argentina",
+    "language": [
+        "spa"
+    ],
+    "title": "Datos Argentina",
+    "issued": "2016-04-14T19:48:05.433640-03:00",
+    "rights": "Derechos especificados en la licencia.",
+    "modified": "2016-04-19T19:48:05.433640-03:00",
+    "dataset": [
+        {
+            "publisher": {
+                "mbox": "onc@modernizacion.gob.ar",
+                "name": "Ministerio de Modernización. Secretaría de Modernización Administrativa. Oficina Nacional de Contrataciones"
+            },
+            "license": "Open Data Commons Open Database License 1.0",
+            "description": "Datos correspondientes al Sistema de Contrataciones Electrónicas (Argentina Compra)",
+            "superTheme": [
+                "econ"
+            ],
+            "title": "Sistema de contrataciones electrónicas",
+            "issued": "2016-04-14T19:48:05.433640-03:00",
+            "temporal": "2015-01-01/2015-12-31",
+            "modified": "2016-04-19T19:48:05.433640-03:00",
+            "language": [
+                "spa"
+            ],
+            "theme": [
+                "contrataciones",
+                "compras",
+                "convocatorias"
+            ],
+            "keyword": [
+                "bienes",
+                "compras",
+                "contrataciones",
+                "bienes y compras"
+            ],
+            "accrualPeriodicity": "R/P1Y",
+            "spatial": "ARG",
+            "identifier": "99db6631-d1c9-470b-a73e-c62daa32c777",
+            "contactPoint": {
+                "hasEmail": "onc-compraselectronicas@modernizacion.gob.ar",
+                "fn": "Ministerio de Modernización. Secretaría de Modernización Administrativa. Oficina Nacional de Contrataciones. Dirección de Compras Electrónicas."
+            },
+            "landingPage": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra",
+            "distribution": [
+                {
+                    "accessURL": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra/archivo/fa3603b3-0af7-43cc-9da9-90a512217d8a",
+                    "identifier": "d_7d4d816f-3a40-476e-ab71-d48a3f0eb3c8",
+                    "description": "Listado de las convocatorias abiertas durante el año 2015 en el sistema de contrataciones electrónicas",
+                    "license": "Open Data Commons Open Database License 1.0",
+                    "title": "Convocatorias abiertas durante el año 2015",
+                    "dataset_identifier": "99db6631-d1c9-470b-a73e-c62daa32c420",
+                    "byteSize": 5120,
+                    "type": "documentation",
+                    "format": "PDF",
+                    "rights": "Derechos especificados en la licencia.",
+                    "mediaType": "application/pdf",
+                    "modified": "2016-04-19T19:48:05.433640-03:00",
+                    "downloadURL": "http://186.33.211.253/dataset/99db6631-d1c9-470b-a73e-c62daa32c420/resource/4b7447cb-31ff-4352-96c3-589d212e1cc9/download/convocatorias-abiertas-anio-2015.pdf",
+                    "issued": "2016-04-14T19:48:05.433640-03:00",
+                    "fileName": "convocatoriasabiertasduranteelao.pdf"
+                },
+                {
+                    "accessURL": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra/archivo/fa3603b3-0af7-43cc-9da9-90a512217d8a",
+                    "identifier": "11",
+                    "description": "Listado de las convocatorias abiertas durante el año 2015 en el sistema de contrataciones electrónicas",
+                    "license": "Open Data Commons Open Database License 1.0",
+                    "title": "Convocatorias abiertas durante el año 2015",
+                    "dataset_identifier": "99db6631-d1c9-470b-a73e-c62daa32c777",
+                    "byteSize": 5120,
+                    "type": "file",
+                    "format": "CSV",
+                    "rights": "Derechos especificados en la licencia.",
+                    "mediaType": "text/csv",
+                    "modified": "2016-04-19T19:48:05.433640-03:00",
+                    "downloadURL": "http://186.33.211.253/dataset/99db6631-d1c9-470b-a73e-c62daa32c420/resource/4b7447cb-31ff-4352-96c3-589d212e1cc9/download/convocatorias-abiertas-anio-2015.csv",
+                    "field": [
+                        {
+                            "title": "procedimiento_id",
+                            "type": "integer",
+                            "id": "proc12",
+                            "description": "Identificador único del procedimiento de contratación"
+                        },
+                        {
+                            "type": "integer",
+                            "description": "Identificador único del organismo que realiza la convocatoria. Organismo de máximo nivel jerárquico al que pertenece la unidad operativa de contrataciones.",
+                            "title": "organismo_unidad_operativa_contrataciones_id"
+                        },
+                        {
+                            "type": "integer",
+                            "description": "Identificador único de la unidad operativa de contrataciones",
+                            "title": "unidad_operativa_contrataciones_id"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Organismo que realiza la convocatoria. Organismo de máximo nivel jerárquico al que pertenece la unidad operativa de contrataciones.",
+                            "title": "organismo_unidad_operativa_contrataciones_desc"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Unidad operativa de contrataciones.",
+                            "title": "unidad_operativa_contrataciones_desc"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Tipo de procedimiento al que se adecua la contratación.",
+                            "title": "tipo_procedimiento_contratacion"
+                        },
+                        {
+                            "type": "date",
+                            "description": "Año en el que se inició el proceso de la convocatoria.",
+                            "title": "ejercicio_procedimiento_anio"
+                        },
+                        {
+                            "type": "date",
+                            "description": "Fecha de publicación de la convocatoria en formato AAAA-MM-DD, ISO 8601.",
+                            "title": "fecha_publicacion_convocatoria"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Modalidad bajo la cual se realiza la convocatoria.",
+                            "title": "modalidad_convocatoria"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Clase de la convocatoria.",
+                            "title": "clase_convocatoria"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Objeto/objetivo de la convocatoria",
+                            "title": "objeto_convocatoria"
+                        }
+                    ],
+                    "issued": "2016-04-14T19:48:05.433640-03:00",
+                    "fileName": "convocatoriasabiertasduranteelao.csv"
+                }
+            ],
+            "source": "Ministerio de modernizacion"
+        }
+    ],
+    "identifier": "7d4d816f-3a40-476e-ab71-d48a3f0eb3c8",
+    "version": "1.1",
+    "spatial": "ARG",
+    "superThemeTaxonomy": "http://datos.gob.ar/superThemeTaxonomy.json",
+    "themeTaxonomy": [
+        {
+            "label": "Convocatorias",
+            "description": "Datasets sobre licitaciones en estado de convocatoria.",
+            "id": "convocatorias"
+        },
+        {
+            "label": "Adquisición",
+            "description": "Datasets sobre compras realizadas.",
+            "id": "compras"
+        },
+        {
+            "label": "Contrataciones",
+            "description": "Datasets sobre contrataciones.",
+            "id": "contrataciones"
+        },
+        {
+            "label": "Adjudicaciones",
+            "description": "Datasets sobre licitaciones adjudicadas.",
+            "id": "adjudicaciones"
+        },
+        {
+            "label": "Normativa",
+            "description": "Datasets sobre normativa para compras y contrataciones.",
+            "id": "normativa"
+        },
+        {
+            "label": "Proveeduría",
+            "description": "Datasets sobre proveedores del Estado.",
+            "id": "proveedores"
+        }
+    ],
+    "homepage": "http://datos.gob.ar"
+}

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -705,6 +705,9 @@ class RestoreToCKANTestCase(FederationSuite):
             r'[^a-z-_]+', '', cls.catalog['title']).lower())
         cls.dataset = cls.catalog.datasets[0]
         cls.dataset_id = cls.dataset['identifier']
+        cls.bad_catalog = pydatajson.DataJson(cls.get_sample(
+            'numeric_distribution_identifier.json'))
+        cls.bad_dataset_id = '99db6631-d1c9-470b-a73e-c62daa32c777'
 
     def test_restore_dataset_to_ckan(self, mock_push):
         def test_strategy(_catalog, _dist):
@@ -714,6 +717,14 @@ class RestoreToCKANTestCase(FederationSuite):
         mock_push.assert_called_with(self.catalog, 'owner_org',
                                      self.dataset_id, 'portal', 'apikey', None,
                                      False, False, test_strategy, None)
+
+    def test_restore_with_numeric_distribution_identifier(self, mock_push):
+        def test_strategy(_catalog, _dist):
+            return False
+        with self.assertRaises(NumericDistributionIdentifierError):
+            restore_dataset_to_ckan(self.bad_catalog, 'owner_org',
+                                    self.bad_dataset_id, 'portal',
+                                    'apikey', test_strategy)
 
     @patch('pydatajson.federation.push_new_themes')
     def test_restore_organization_to_ckan(self, mock_push_thm, mock_push_dst):

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -716,15 +716,12 @@ class RestoreToCKANTestCase(FederationSuite):
                                      False, False, test_strategy, None)
 
     def test_restore_with_numeric_distribution_identifier(self, mock_push):
-        def test_strategy(_catalog, _dist):
-            return False
         bad_catalog = pydatajson.DataJson(self.get_sample(
             'numeric_distribution_identifier.json'))
         bad_dataset_id = '99db6631-d1c9-470b-a73e-c62daa32c777'
         with self.assertRaises(NumericDistributionIdentifierError):
             restore_dataset_to_ckan(bad_catalog, 'owner_org',
-                                    bad_dataset_id, 'portal',
-                                    'apikey', test_strategy)
+                                    bad_dataset_id, 'portal', 'apikey')
 
     @patch('pydatajson.federation.push_new_themes')
     def test_restore_organization_to_ckan(self, mock_push_thm, mock_push_dst):

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -705,9 +705,6 @@ class RestoreToCKANTestCase(FederationSuite):
             r'[^a-z-_]+', '', cls.catalog['title']).lower())
         cls.dataset = cls.catalog.datasets[0]
         cls.dataset_id = cls.dataset['identifier']
-        cls.bad_catalog = pydatajson.DataJson(cls.get_sample(
-            'numeric_distribution_identifier.json'))
-        cls.bad_dataset_id = '99db6631-d1c9-470b-a73e-c62daa32c777'
 
     def test_restore_dataset_to_ckan(self, mock_push):
         def test_strategy(_catalog, _dist):
@@ -721,9 +718,12 @@ class RestoreToCKANTestCase(FederationSuite):
     def test_restore_with_numeric_distribution_identifier(self, mock_push):
         def test_strategy(_catalog, _dist):
             return False
+        bad_catalog = pydatajson.DataJson(self.get_sample(
+            'numeric_distribution_identifier.json'))
+        bad_dataset_id = '99db6631-d1c9-470b-a73e-c62daa32c777'
         with self.assertRaises(NumericDistributionIdentifierError):
-            restore_dataset_to_ckan(self.bad_catalog, 'owner_org',
-                                    self.bad_dataset_id, 'portal',
+            restore_dataset_to_ckan(bad_catalog, 'owner_org',
+                                    bad_dataset_id, 'portal',
                                     'apikey', test_strategy)
 
     @patch('pydatajson.federation.push_new_themes')


### PR DESCRIPTION
- Creo excepción específica para distribuciones cuyos identificadores son puramente numéricos
- Agrego paso de validación de las distribuciones de los datasets al querer restaurar datasets
- Agrego caso de test para un .json con una distribución puramente numérica, y otra no puramente numérica

Closes #262 