### PR TITLE
Uso NamedTemporaryFile en lectura de catálogos en XLSX

### DIFF
--- a/pydatajson/readers.py
+++ b/pydatajson/readers.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os.path
 import warnings
+from tempfile import NamedTemporaryFile
 
 import openpyxl as pyxl
 import requests
@@ -246,11 +247,10 @@ def read_xlsx_catalog(xlsx_path_or_url, logger=None, verify=False,
     parsed_url = urlparse(xlsx_path_or_url)
     if parsed_url.scheme in ["http", "https"]:
         res = requests.get(xlsx_path_or_url, verify=verify, timeout=timeout)
-        tmpfilename = ".tmpfile.xlsx"
-        with io.open(tmpfilename, 'wb') as tmpfile:
+        with NamedTemporaryFile() as tmpfile:
             tmpfile.write(res.content)
-        catalog_dict = read_local_xlsx_catalog(tmpfilename, logger)
-        os.remove(tmpfilename)
+            catalog_dict = read_local_xlsx_catalog(tmpfile.name, logger)
+
     else:
         # Si xlsx_path_or_url parece ser una URL remota, lo advierto.
         path_start = parsed_url.path.split(".")[0]

--- a/pydatajson/readers.py
+++ b/pydatajson/readers.py
@@ -249,6 +249,7 @@ def read_xlsx_catalog(xlsx_path_or_url, logger=None, verify=False,
         res = requests.get(xlsx_path_or_url, verify=verify, timeout=timeout)
         with NamedTemporaryFile() as tmpfile:
             tmpfile.write(res.content)
+            tmpfile.flush()
             catalog_dict = read_local_xlsx_catalog(tmpfile.name, logger)
 
     else:


### PR DESCRIPTION
Evita condiciones de carrera en contextos de múltiples procesos intentando leer catálogos y escribiendo
archivos temporales a la misma ruta.

Closes #272 