### PR TITLE
276 agregar parametros timezones origen y destino

### DIFF
--- a/pydatajson/ckan_utils.py
+++ b/pydatajson/ckan_utils.py
@@ -6,8 +6,7 @@ import json
 import re
 import logging
 
-import pytz
-from dateutil import parser
+from dateutil import parser, tz
 
 from pydatajson.constants import DEFAULT_TIMEZONE
 from .helpers import title_to_name
@@ -124,16 +123,14 @@ def convert_iso_string_to_dst_timezone(date_string,
                                        dst_tz=DEFAULT_TIMEZONE):
     date_time = parser.parse(date_string)
 
-    dest_timezone = pytz.timezone(dst_tz)
+    dest_timezone = tz.gettz(dst_tz)
     if date_time.tzinfo is not None:
         date_time = date_time.astimezone(dest_timezone)
     else:
-        origin_timezone = pytz.timezone(origin_tz)
+        origin_timezone = tz.gettz(origin_tz)
         date_time = date_time.replace(tzinfo=origin_timezone)
-        origin_timezone.normalize(date_time)
         date_time = date_time.astimezone(dest_timezone)
 
-    dest_timezone.normalize(date_time)
     date_time = date_time.replace(tzinfo=None)
     return date_time.isoformat()
 

--- a/pydatajson/ckan_utils.py
+++ b/pydatajson/ckan_utils.py
@@ -124,12 +124,11 @@ def convert_iso_string_to_dst_timezone(date_string,
     date_time = parser.parse(date_string)
 
     dest_timezone = tz.gettz(dst_tz)
-    if date_time.tzinfo is not None:
-        date_time = date_time.astimezone(dest_timezone)
-    else:
+    if date_time.tzinfo is None:
         origin_timezone = tz.gettz(origin_tz)
         date_time = date_time.replace(tzinfo=origin_timezone)
-        date_time = date_time.astimezone(dest_timezone)
+
+    date_time = date_time.astimezone(dest_timezone)
 
     date_time = date_time.replace(tzinfo=None)
     return date_time.isoformat()

--- a/pydatajson/ckan_utils.py
+++ b/pydatajson/ckan_utils.py
@@ -137,7 +137,8 @@ def convert_iso_string_to_default_timezone(date_string,
 
 
 def map_distributions_to_resources(distributions, catalog_id=None,
-                                   origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE):
+                                   origin_tz=DEFAULT_TIMEZONE,
+                                   dst_tz=DEFAULT_TIMEZONE):
     resources = []
     for distribution in distributions:
         resource = dict()

--- a/pydatajson/ckan_utils.py
+++ b/pydatajson/ckan_utils.py
@@ -119,9 +119,9 @@ def _get_theme_label(catalog, theme):
     return label
 
 
-def convert_iso_string_to_default_timezone(date_string,
-                                           origin_tz=DEFAULT_TIMEZONE,
-                                           dst_tz=DEFAULT_TIMEZONE):
+def convert_iso_string_to_dst_timezone(date_string,
+                                       origin_tz=DEFAULT_TIMEZONE,
+                                       dst_tz=DEFAULT_TIMEZONE):
     date_time = parser.parse(date_string)
 
     dest_timezone = pytz.timezone(dst_tz)
@@ -150,18 +150,18 @@ def map_distributions_to_resources(distributions, catalog_id=None,
         resource['name'] = distribution['title']
         resource['url'] = distribution['downloadURL']
         resource['created'] = \
-            convert_iso_string_to_default_timezone(distribution['issued'],
-                                                   origin_tz=origin_tz,
-                                                   dst_tz=dst_tz)
+            convert_iso_string_to_dst_timezone(distribution['issued'],
+                                               origin_tz=origin_tz,
+                                               dst_tz=dst_tz)
         #       Recomendados y opcionales
         resource['description'] = distribution.get('description')
         resource['format'] = distribution.get('format')
         last_modified = distribution.get('modified')
         if last_modified:
             resource['last_modified'] = \
-                convert_iso_string_to_default_timezone(last_modified,
-                                                       origin_tz=origin_tz,
-                                                       dst_tz=dst_tz)
+                convert_iso_string_to_dst_timezone(last_modified,
+                                                   origin_tz=origin_tz,
+                                                   dst_tz=dst_tz)
         resource['mimetype'] = distribution.get('mediaType')
         resource['size'] = distribution.get('byteSize')
         resource['accessURL'] = distribution.get('accessURL')

--- a/pydatajson/ckan_utils.py
+++ b/pydatajson/ckan_utils.py
@@ -26,7 +26,8 @@ def append_attribute_to_extra(package, dataset, attribute, serialize=False):
 
 def map_dataset_to_package(catalog, dataset, owner_org, catalog_id=None,
                            demote_superThemes=True, demote_themes=True,
-                           origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE):
+                           origin_tz=DEFAULT_TIMEZONE,
+                           dst_tz=DEFAULT_TIMEZONE):
     package = dict()
     package['extras'] = []
 
@@ -118,7 +119,9 @@ def _get_theme_label(catalog, theme):
     return label
 
 
-def convert_iso_string_to_default_timezone(date_string, origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE):
+def convert_iso_string_to_default_timezone(date_string,
+                                           origin_tz=DEFAULT_TIMEZONE,
+                                           dst_tz=DEFAULT_TIMEZONE):
     date_time = parser.parse(date_string)
 
     dest_timezone = pytz.timezone(dst_tz)
@@ -133,7 +136,8 @@ def convert_iso_string_to_default_timezone(date_string, origin_tz=DEFAULT_TIMEZO
     return date_time.isoformat()
 
 
-def map_distributions_to_resources(distributions, catalog_id=None, origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE):
+def map_distributions_to_resources(distributions, catalog_id=None,
+                                   origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE):
     resources = []
     for distribution in distributions:
         resource = dict()

--- a/pydatajson/ckan_utils.py
+++ b/pydatajson/ckan_utils.py
@@ -130,8 +130,10 @@ def convert_iso_string_to_default_timezone(date_string,
     else:
         origin_timezone = pytz.timezone(origin_tz)
         date_time = date_time.replace(tzinfo=origin_timezone)
+        origin_timezone.normalize(date_time)
         date_time = date_time.astimezone(dest_timezone)
 
+    dest_timezone.normalize(date_time)
     date_time = date_time.replace(tzinfo=None)
     return date_time.isoformat()
 

--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -33,8 +33,8 @@ def push_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier,
             portal_url (str): La URL del portal CKAN de destino.
             apikey (str): La apikey de un usuario con los permisos que le
                 permitan crear o actualizar el dataset.
-            catalog_id (str or None): El prefijo con el que va a preceder el id del
-                dataset en catálogo destino.
+            catalog_id (str or None): El prefijo con el que va a preceder
+                el id del dataset en catálogo destino.
             demote_superThemes(bool): Si está en true, los ids de los super
                 themes del dataset, se propagan como grupo.
             demote_themes(bool): Si está en true, los labels de los themes
@@ -47,8 +47,8 @@ def push_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier,
                 distribuciones cuyo accessURL se regenerar en el portal de
                 destino. Para el resto, el portal debe mantiene el valor pasado
                 en el DataJson.
-            origin_tz(str): Timezone de origen, un string (EJ: Africa/Bamako) el
-                cual identifica el timezone del emisor del DataJson.
+            origin_tz(str): Timezone de origen, un string (EJ: Africa/Bamako)
+                el cual identifica el timezone del emisor del DataJson.
             dst_tz(str): Timezone de destino, un string
                 (EJ: Antarctica/Palmer) el cual identifica el timezone del
                 receptor del DataJson, comunmente el timezone del servidor.
@@ -270,7 +270,8 @@ def push_theme_to_ckan(catalog, portal_url, apikey,
 def restore_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier,
                             portal_url, apikey, download_strategy=None,
                             generate_new_access_url=None,
-                            origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE):
+                            origin_tz=DEFAULT_TIMEZONE,
+                            dst_tz=DEFAULT_TIMEZONE):
     """Restaura la metadata de un dataset en el portal pasado por parámetro.
 
         Args:
@@ -289,8 +290,8 @@ def restore_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier,
                     distribuciones cuyo accessURL se regenerar en el portal de
                     destino. Para el resto, el portal debe mantiene el valor
                     pasado en el DataJson.
-            origin_tz(str): Timezone de origen, un string (EJ: Africa/Bamako) el
-                cual identifica el timezone del emisor del DataJson.
+            origin_tz(str): Timezone de origen, un string (EJ: Africa/Bamako)
+                el cual identifica el timezone del emisor del DataJson.
             dst_tz(str): Timezone de destino, un string
                 (EJ: Antarctica/Palmer) el cual identifica el timezone del
                 receptor del DataJson, comunmente el timezone del servidor.
@@ -312,17 +313,20 @@ def restore_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier,
                 'este es numerico. Por favor, cambielo e intente de '
                 'nuevo'.format(distribution["identifier"]))
 
-    return push_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier,
-                                portal_url, apikey, catalog_id=None, demote_superThemes=False,
-                                demote_themes=False, download_strategy=download_strategy,
-                                generate_new_access_url=generate_new_access_url,
-                                origin_tz=origin_tz, dst_tz=dst_tz)
+    return push_dataset_to_ckan(
+        catalog, owner_org, dataset_origin_identifier,
+        portal_url, apikey, catalog_id=None, demote_superThemes=False,
+        demote_themes=False, download_strategy=download_strategy,
+        generate_new_access_url=generate_new_access_url,
+        origin_tz=origin_tz, dst_tz=dst_tz
+    )
 
 
 def harvest_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier,
                             portal_url, apikey, catalog_id,
                             download_strategy=None,
-                            origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE):
+                            origin_tz=DEFAULT_TIMEZONE,
+                            dst_tz=DEFAULT_TIMEZONE):
     """Federa la metadata de un dataset en el portal pasado por parámetro.
 
         Args:
@@ -338,8 +342,8 @@ def harvest_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier,
                 bool. Sobre las distribuciones que evalúa True, descarga el
                 recurso en el downloadURL y lo sube al portal de destino.
                 Por default no sube ninguna distribución.
-            origin_tz(str): Timezone de origen, un string (EJ: Africa/Bamako) el
-                cual identifica el timezone del emisor del DataJson.
+            origin_tz(str): Timezone de origen, un string (EJ: Africa/Bamako)
+                el cual identifica el timezone del emisor del DataJson.
             dst_tz(str): Timezone de destino, un string
                 (EJ: Antarctica/Palmer) el cual identifica el timezone del
                 receptor del DataJson, comunmente el timezone del servidor.
@@ -356,7 +360,8 @@ def harvest_dataset_to_ckan(catalog, owner_org, dataset_origin_identifier,
 def harvest_catalog_to_ckan(catalog, portal_url, apikey, catalog_id,
                             dataset_list=None, owner_org=None,
                             download_strategy=None,
-                            origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE):
+                            origin_tz=DEFAULT_TIMEZONE,
+                            dst_tz=DEFAULT_TIMEZONE):
     """Federa los datasets de un catálogo al portal pasado por parámetro.
 
         Args:
@@ -374,8 +379,8 @@ def harvest_catalog_to_ckan(catalog, portal_url, apikey, catalog_id,
                 bool. Sobre las distribuciones que evalúa True, descarga el
                 recurso en el downloadURL y lo sube al portal de destino.
                 Por default no sube ninguna distribución.
-            origin_tz(str): Timezone de origen, un string (EJ: Africa/Bamako) el
-                cual identifica el timezone del emisor del DataJson.
+            origin_tz(str): Timezone de origen, un string (EJ: Africa/Bamako)
+                el cual identifica el timezone del emisor del DataJson.
             dst_tz(str): Timezone de destino, un string
                 (EJ: Antarctica/Palmer) el cual identifica el timezone del
                 receptor del DataJson, comunmente el timezone del servidor.
@@ -713,8 +718,8 @@ def restore_catalog_to_ckan(catalog, origin_portal_url, destination_portal_url,
                     distribuciones cuyo accessURL se regenerar en el portal de
                     destino. Para el resto, el portal debe mantiene el valor
                     pasado en el DataJson.
-                origin_tz(str): Timezone de origen, un string (EJ: Africa/Bamako) el
-                    cual identifica el timezone del emisor del DataJson.
+                origin_tz(str): Timezone de origen, un string (EJ: Africa/Bamako)
+                    el cual identifica el timezone del emisor del DataJson.
                 dst_tz(str): Timezone de destino, un string
                     (EJ: Antarctica/Palmer) el cual identifica el timezone del
                     receptor del DataJson, comunmente el timezone del servidor.

--- a/pydatajson/federation.py
+++ b/pydatajson/federation.py
@@ -613,8 +613,8 @@ def restore_organizations_to_ckan(catalog, organizations, portal_url, apikey,
                 distribuciones cuyo accessURL se regenerar en el portal de
                 destino. Para el resto, el portal debe mantiene el valor
                 pasado en el DataJson.
-            origin_tz(str): Timezone de origen, un string (EJ: Africa/Bamako) el
-                cual identifica el timezone del emisor del DataJson.
+            origin_tz(str): Timezone de origen, un string (EJ: Africa/Bamako)
+                el cual identifica el timezone del emisor del DataJson.
             dst_tz(str): Timezone de destino, un string
                 (EJ: Antarctica/Palmer) el cual identifica el timezone del
                 receptor del DataJson, comunmente el timezone del servidor.
@@ -661,8 +661,8 @@ def restore_organization_to_ckan(catalog, owner_org, portal_url, apikey,
                     distribuciones cuyo accessURL se regenerar en el portal de
                     destino. Para el resto, el portal debe mantiene el valor
                     pasado en el DataJson.
-            origin_tz(str): Timezone de origen, un string (EJ: Africa/Bamako) el
-                cual identifica el timezone del emisor del DataJson.
+            origin_tz(str): Timezone de origen, un string (EJ: Africa/Bamako)
+                el cual identifica el timezone del emisor del DataJson.
             dst_tz(str): Timezone de destino, un string
                 (EJ: Antarctica/Palmer) el cual identifica el timezone del
                 receptor del DataJson, comunmente el timezone del servidor.
@@ -697,7 +697,8 @@ def restore_organization_to_ckan(catalog, owner_org, portal_url, apikey,
 def restore_catalog_to_ckan(catalog, origin_portal_url, destination_portal_url,
                             apikey, download_strategy=None,
                             generate_new_access_url=None,
-                            origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE):
+                            origin_tz=DEFAULT_TIMEZONE,
+                            dst_tz=DEFAULT_TIMEZONE):
     """Restaura los datasets de un catálogo original al portal pasado
        por parámetro. Si hay temas presentes en el DataJson que no están en
        el portal de CKAN, los genera.
@@ -718,8 +719,9 @@ def restore_catalog_to_ckan(catalog, origin_portal_url, destination_portal_url,
                     distribuciones cuyo accessURL se regenerar en el portal de
                     destino. Para el resto, el portal debe mantiene el valor
                     pasado en el DataJson.
-                origin_tz(str): Timezone de origen, un string (EJ: Africa/Bamako)
-                    el cual identifica el timezone del emisor del DataJson.
+                origin_tz(str): Timezone de origen, un string
+                    (EJ: Africa/Bamako) el cual identifica el timezone
+                    del emisor del DataJson.
                 dst_tz(str): Timezone de destino, un string
                     (EJ: Antarctica/Palmer) el cual identifica el timezone del
                     receptor del DataJson, comunmente el timezone del servidor.

--- a/tests/test_ckan_utils.py
+++ b/tests/test_ckan_utils.py
@@ -367,43 +367,43 @@ class DatetimeConversionTests(unittest.TestCase):
     def test_timezone_is_set_to_default_if_none_given(self):
         date = '2018-01-29T17:14:09.291510'
         expected_date = '2018-01-29T17:14:09.291510'
-        res = convert_iso_string_to_default_timezone(date)
+        res = convert_iso_string_to_dst_timezone(date)
         self.assertEqual(res, expected_date)
 
     def test_timezone_maintained_if_given(self):
         date = '2018-01-29T14:14:09.291510+03:00'
         expected_date = '2018-01-29T08:14:09.291510'
-        res = convert_iso_string_to_default_timezone(date)
+        res = convert_iso_string_to_dst_timezone(date)
         self.assertEqual(res, expected_date)
 
     def test_timezone_is_set_to_default_if_none_given_without_ms(self):
         date = '2018-01-29T17:14:09'
         expected_date = '2018-01-29T17:14:09'
-        res = convert_iso_string_to_default_timezone(date)
+        res = convert_iso_string_to_dst_timezone(date)
         self.assertEqual(res, expected_date)
 
     def test_timezone_maintained_if_given_without_ms(self):
         date = '2018-01-29T14:14:09-06:00'
         expected_date = '2018-01-29T17:14:09'
-        res = convert_iso_string_to_default_timezone(date)
+        res = convert_iso_string_to_dst_timezone(date)
         self.assertEqual(res, expected_date)
 
     def test_timezone_is_set_to_default_if_none_given_without_seconds(self):
         date = '2018-01-29T17:14'
         expected_date = '2018-01-29T17:14:00'
-        res = convert_iso_string_to_default_timezone(date)
+        res = convert_iso_string_to_dst_timezone(date)
         self.assertEqual(res, expected_date)
 
     def test_timezone_maintained_if_given_without_seconds(self):
         date = '2018-01-29T14:14+04:00'
         expected_date = '2018-01-29T07:14:00'
-        res = convert_iso_string_to_default_timezone(date)
+        res = convert_iso_string_to_dst_timezone(date)
         self.assertEqual(res, expected_date)
 
     def test_timezone_is_set_to_default_if_none_given_without_time(self):
         date = '2018-01-29'
         expected_date = '2018-01-29T00:00:00'
-        res = convert_iso_string_to_default_timezone(date)
+        res = convert_iso_string_to_dst_timezone(date)
         self.assertEqual(res, expected_date)
 
     def test_timezone_is_set_to_dst_tz_with_default_origin_tz(self):
@@ -416,7 +416,7 @@ class DatetimeConversionTests(unittest.TestCase):
                           expected_date_new_york,
                           expected_date_london]
         res_dates = [
-            convert_iso_string_to_default_timezone(
+            convert_iso_string_to_dst_timezone(
                 date, dst_tz=self.dates[key]
             ) for key in self.dates
         ]
@@ -433,7 +433,7 @@ class DatetimeConversionTests(unittest.TestCase):
                           expected_date_new_york,
                           expected_date_london]
         res_dates = [
-            convert_iso_string_to_default_timezone(
+            convert_iso_string_to_dst_timezone(
                 date, dst_tz=self.dates[key]
             ) for key in self.dates
         ]
@@ -450,7 +450,7 @@ class DatetimeConversionTests(unittest.TestCase):
                           expected_date_new_york,
                           expected_date_london]
         res_dates = [
-            convert_iso_string_to_default_timezone(
+            convert_iso_string_to_dst_timezone(
                 date,
                 origin_tz=self.dates['tz_london'],  # GMT+1
                 dst_tz=self.dates[key]
@@ -469,7 +469,7 @@ class DatetimeConversionTests(unittest.TestCase):
                           expected_date_new_york,
                           expected_date_london]
         res_dates = [
-            convert_iso_string_to_default_timezone(
+            convert_iso_string_to_dst_timezone(
                 date,
                 origin_tz=self.dates['tz_london'],  # GMT+1
                 dst_tz=self.dates[key]
@@ -488,7 +488,7 @@ class DatetimeConversionTests(unittest.TestCase):
                           expected_date_new_york,
                           expected_date_london]
         res_dates = [
-            convert_iso_string_to_default_timezone(
+            convert_iso_string_to_dst_timezone(
                 date,
                 origin_tz=self.dates['tz_new_york'],  # GMT-4
                 dst_tz=self.dates[key]

--- a/tests/test_ckan_utils.py
+++ b/tests/test_ckan_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+import sys
 import unittest
 import os
 from .context import pydatajson
@@ -498,9 +499,12 @@ class DatetimeConversionTests(unittest.TestCase):
         self._assert_dates_equal(expected_dates, res_dates)
 
     def _assert_dates_equal(self, expected_dates, dates):
+        values = list(self.dates.values()) \
+            if sys.version_info[0] >= 3 \
+            else self.dates.values()
         for i in range(max(len(expected_dates), len(dates))):
             self.assertEqual(
                 expected_dates[i],
                 dates[i],
-                msg="dst_tz: %s" % self.dates[list(self.dates)[i]]
+                msg="dst_tz: %s" % values[i]
             )

--- a/tests/test_ckan_utils.py
+++ b/tests/test_ckan_utils.py
@@ -502,5 +502,5 @@ class DatetimeConversionTests(unittest.TestCase):
             self.assertEqual(
                 expected_dates[i],
                 dates[i],
-                msg="dst_tz: %s" % list(self.dates.values())[i]
+                msg="dst_tz: %s" % self.dates[list(self.dates)[i]]
             )

--- a/tests/test_ckan_utils.py
+++ b/tests/test_ckan_utils.py
@@ -499,9 +499,7 @@ class DatetimeConversionTests(unittest.TestCase):
         self._assert_dates_equal(expected_dates, res_dates)
 
     def _assert_dates_equal(self, expected_dates, dates):
-        values = list(self.dates.values()) \
-            if sys.version_info[0] >= 3 \
-            else self.dates.values()
+        values = [self.dates[k] for k in self.dates]
         for i in range(max(len(expected_dates), len(dates))):
             self.assertEqual(
                 expected_dates[i],

--- a/tests/test_ckan_utils.py
+++ b/tests/test_ckan_utils.py
@@ -2,12 +2,12 @@
 
 from __future__ import unicode_literals
 
-import sys
-import unittest
 import os
-from .context import pydatajson
+import unittest
+
 from pydatajson.ckan_utils import *
 from pydatajson.helpers import title_to_name
+from .context import pydatajson
 
 SAMPLES_DIR = os.path.join("tests", "samples")
 
@@ -204,7 +204,7 @@ class DatasetConversionTestCase(unittest.TestCase):
             self.dataset,
             'owner',
             catalog_id=self.catalog_id)
-#       dataset attributes are included in extras
+        #       dataset attributes are included in extras
         extra_attrs = [
             'issued',
             'modified',
@@ -273,7 +273,7 @@ class DatasetConversionTestCase(unittest.TestCase):
                 ('created', 'issued'), ('last_modified', 'modified')]
             for fst, snd in time_attributes:
                 if distribution.get(snd):
-                    dist_time = parser.parse(distribution.get(snd))\
+                    dist_time = parser.parse(distribution.get(snd)) \
                         .replace(tzinfo=None)
                     self.assertEqual(dist_time.isoformat(), resource.get(fst))
                 else:
@@ -358,7 +358,6 @@ class ThemeConversionTests(unittest.TestCase):
 
 
 class DatetimeConversionTests(unittest.TestCase):
-
     dates = {
         'tz_bs_as': 'America/Buenos_Aires',  # GMT-3
         'tz_new_york': 'America/New_York',  # GMT-4
@@ -410,19 +409,22 @@ class DatetimeConversionTests(unittest.TestCase):
     def test_timezone_is_set_to_dst_tz_with_default_origin_tz(self):
         date = '2018-06-29T17:14:09.291510'
         expected_date_bs_as = '2018-06-29T17:14:09.291510'
-        expected_date_new_york = '2018-06-29T17:08:09.291510'
-        expected_date_london = '2018-06-29T22:08:09.291510'
+        expected_date_new_york = '2018-06-29T16:14:09.291510'
+        expected_date_london = '2018-06-29T21:14:09.291510'
 
-        expected_dates = [expected_date_bs_as,
-                          expected_date_new_york,
-                          expected_date_london]
-        res_dates = [
-            convert_iso_string_to_dst_timezone(
-                date, dst_tz=self.dates[key]
-            ) for key in self.dates
-        ]
+        res_bs_as = convert_iso_string_to_dst_timezone(
+            date, dst_tz=self.dates['tz_bs_as']
+        )
+        res_new_york = convert_iso_string_to_dst_timezone(
+            date, dst_tz=self.dates['tz_new_york']
+        )
+        res_london = convert_iso_string_to_dst_timezone(
+            date, dst_tz=self.dates['tz_london']
+        )
 
-        self._assert_dates_equal(expected_dates, res_dates)
+        self.assertEqual(expected_date_bs_as, res_bs_as)
+        self.assertEqual(expected_date_new_york, res_new_york)
+        self.assertEqual(expected_date_london, res_london)
 
     def test_timezone_is_set_to_dst_tz_with_date_tz(self):
         date = '2018-06-29T17:14:09.291510+04:00'
@@ -430,35 +432,45 @@ class DatetimeConversionTests(unittest.TestCase):
         expected_date_new_york = '2018-06-29T09:14:09.291510'
         expected_date_london = '2018-06-29T14:14:09.291510'
 
-        expected_dates = [expected_date_bs_as,
-                          expected_date_new_york,
-                          expected_date_london]
-        res_dates = [
-            convert_iso_string_to_dst_timezone(
-                date, dst_tz=self.dates[key]
-            ) for key in self.dates
-        ]
+        res_bs_as = convert_iso_string_to_dst_timezone(
+            date, dst_tz=self.dates['tz_bs_as']
+        )
+        res_new_york = convert_iso_string_to_dst_timezone(
+            date, dst_tz=self.dates['tz_new_york']
+        )
+        res_london = convert_iso_string_to_dst_timezone(
+            date, dst_tz=self.dates['tz_london']
+        )
 
-        self._assert_dates_equal(expected_dates, res_dates)
+        self.assertEqual(expected_date_bs_as, res_bs_as)
+        self.assertEqual(expected_date_new_york, res_new_york)
+        self.assertEqual(expected_date_london, res_london)
 
     def test_date_timezone_is_set_to_given_origin_tz_without_date_tz(self):
         date = '2018-06-29T17:14:09.291510'
-        expected_date_bs_as = '2018-06-29T14:15:09.291510'
-        expected_date_new_york = '2018-06-29T13:15:09.291510'
+        expected_date_bs_as = '2018-06-29T13:14:09.291510'
+        expected_date_new_york = '2018-06-29T12:14:09.291510'
         expected_date_london = '2018-06-29T17:14:09.291510'
 
-        expected_dates = [expected_date_bs_as,
-                          expected_date_new_york,
-                          expected_date_london]
-        res_dates = [
-            convert_iso_string_to_dst_timezone(
-                date,
-                origin_tz=self.dates['tz_london'],  # GMT+1
-                dst_tz=self.dates[key]
-            ) for key in self.dates
-        ]
+        res_bs_as = convert_iso_string_to_dst_timezone(
+            date,
+            origin_tz=self.dates['tz_london'],  # GMT+1,
+            dst_tz=self.dates['tz_bs_as']
+        )
+        res_new_york = convert_iso_string_to_dst_timezone(
+            date,
+            origin_tz=self.dates['tz_london'],  # GMT+1,
+            dst_tz=self.dates['tz_new_york']
+        )
+        res_london = convert_iso_string_to_dst_timezone(
+            date,
+            origin_tz=self.dates['tz_london'],  # GMT+1,
+            dst_tz=self.dates['tz_london']
+        )
 
-        self._assert_dates_equal(expected_dates, res_dates)
+        self.assertEqual(expected_date_bs_as, res_bs_as)
+        self.assertEqual(expected_date_new_york, res_new_york)
+        self.assertEqual(expected_date_london, res_london)
 
     def test_date_timezone_is_set_to_date_tz_despite_the_origin_tz(self):
         date = '2018-06-29T17:14:09.291510-03:00'
@@ -466,43 +478,48 @@ class DatetimeConversionTests(unittest.TestCase):
         expected_date_new_york = '2018-06-29T16:14:09.291510'
         expected_date_london = '2018-06-29T21:14:09.291510'
 
-        expected_dates = [expected_date_bs_as,
-                          expected_date_new_york,
-                          expected_date_london]
-        res_dates = [
-            convert_iso_string_to_dst_timezone(
-                date,
-                origin_tz=self.dates['tz_london'],  # GMT+1
-                dst_tz=self.dates[key]
-            ) for key in self.dates
-        ]
+        res_bs_as = convert_iso_string_to_dst_timezone(
+            date,
+            origin_tz=self.dates['tz_london'],  # GMT+1,
+            dst_tz=self.dates['tz_bs_as']
+        )
+        res_new_york = convert_iso_string_to_dst_timezone(
+            date,
+            origin_tz=self.dates['tz_london'],  # GMT+1,
+            dst_tz=self.dates['tz_new_york']
+        )
+        res_london = convert_iso_string_to_dst_timezone(
+            date,
+            origin_tz=self.dates['tz_london'],  # GMT+1,
+            dst_tz=self.dates['tz_london']
+        )
 
-        self._assert_dates_equal(expected_dates, res_dates)
+        self.assertEqual(expected_date_bs_as, res_bs_as)
+        self.assertEqual(expected_date_new_york, res_new_york)
+        self.assertEqual(expected_date_london, res_london)
 
     def test_res_date_is_congruent_to_given_origin_and_dst_tzs(self):
         date = '2018-06-29T15:14:09.291510'
-        expected_date_bs_as = '2018-06-29T17:10:09.291510'
+        expected_date_bs_as = '2018-06-29T16:14:09.291510'
         expected_date_new_york = '2018-06-29T15:14:09.291510'
-        expected_date_london = '2018-06-29T21:10:09.291510'
+        expected_date_london = '2018-06-29T20:14:09.291510'
 
-        expected_dates = [expected_date_bs_as,
-                          expected_date_new_york,
-                          expected_date_london]
-        res_dates = [
-            convert_iso_string_to_dst_timezone(
-                date,
-                origin_tz=self.dates['tz_new_york'],  # GMT-4
-                dst_tz=self.dates[key]
-            ) for key in self.dates
-        ]
+        res_bs_as = convert_iso_string_to_dst_timezone(
+            date,
+            origin_tz=self.dates['tz_new_york'],  # GMT-4,
+            dst_tz=self.dates['tz_bs_as']
+        )
+        res_new_york = convert_iso_string_to_dst_timezone(
+            date,
+            origin_tz=self.dates['tz_new_york'],  # GMT-4,
+            dst_tz=self.dates['tz_new_york']
+        )
+        res_london = convert_iso_string_to_dst_timezone(
+            date,
+            origin_tz=self.dates['tz_new_york'],  # GMT-4,
+            dst_tz=self.dates['tz_london']
+        )
 
-        self._assert_dates_equal(expected_dates, res_dates)
-
-    def _assert_dates_equal(self, expected_dates, dates):
-        values = [self.dates[k] for k in self.dates]
-        for i in range(max(len(expected_dates), len(dates))):
-            self.assertEqual(
-                expected_dates[i],
-                dates[i],
-                msg="dst_tz: %s" % values[i]
-            )
+        self.assertEqual(expected_date_bs_as, res_bs_as)
+        self.assertEqual(expected_date_new_york, res_new_york)
+        self.assertEqual(expected_date_london, res_london)

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -710,10 +710,13 @@ class RestoreToCKANTestCase(FederationSuite):
         def test_strategy(_catalog, _dist):
             return False
         restore_dataset_to_ckan(self.catalog, 'owner_org', self.dataset_id,
-                                'portal', 'apikey', test_strategy)
+                                'portal', 'apikey', download_strategy=test_strategy)
         mock_push.assert_called_with(self.catalog, 'owner_org',
-                                     self.dataset_id, 'portal', 'apikey', None,
-                                     False, False, test_strategy, None)
+                                     self.dataset_id, 'portal', 'apikey',
+                                     catalog_id=None, demote_superThemes=False,
+                                     demote_themes=False, download_strategy=test_strategy,
+                                     generate_new_access_url=None,
+                                     origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE)
 
     def test_restore_with_numeric_distribution_identifier(self, mock_push):
         bad_catalog = pydatajson.DataJson(self.get_sample(
@@ -733,8 +736,11 @@ class RestoreToCKANTestCase(FederationSuite):
         mock_push_thm.assert_called_with(self.catalog, 'portal', 'apikey')
         for identifier in identifiers:
             mock_push_dst.assert_any_call(self.catalog, 'owner_org',
-                                          identifier, 'portal', 'apikey', None,
-                                          False, False, None, None)
+                                          identifier, 'portal', 'apikey',
+                                          catalog_id=None, demote_superThemes=False,
+                                          demote_themes=False, download_strategy=None,
+                                          generate_new_access_url=None,
+                                          origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE)
 
     @patch('pydatajson.federation.push_new_themes')
     def test_restore_failing_organization_to_ckan(self, mock_push_thm,
@@ -750,7 +756,10 @@ class RestoreToCKANTestCase(FederationSuite):
         mock_push_thm.assert_called_with(self.catalog, 'portal', 'apikey')
         mock_push_dst.assert_called_with(self.catalog, 'owner_org',
                                          identifiers[1], 'portal', 'apikey',
-                                         None, False, False, None, None)
+                                         catalog_id=None, demote_superThemes=False,
+                                         demote_themes=False, download_strategy=None,
+                                         generate_new_access_url=None,
+                                         origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE)
 
     @patch('pydatajson.federation.push_new_themes')
     @patch('ckanapi.remoteckan.ActionShortcut')
@@ -768,10 +777,16 @@ class RestoreToCKANTestCase(FederationSuite):
                                          'destination', 'apikey')
         mock_push_dst.assert_any_call(self.catalog, 'org_1',
                                       identifiers[0], 'destination', 'apikey',
-                                      None, False, False, None, None)
+                                      catalog_id=None, demote_superThemes=False,
+                                      demote_themes=False, download_strategy=None,
+                                      generate_new_access_url=None,
+                                      origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE)
         mock_push_dst.assert_any_call(self.catalog, 'org_2',
                                       identifiers[1], 'destination', 'apikey',
-                                      None, False, False, None, None)
+                                      catalog_id=None, demote_superThemes=False,
+                                      demote_themes=False, download_strategy=None,
+                                      generate_new_access_url=None,
+                                      origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE)
         expected = {'org_1': [identifiers[0]],
                     'org_2': [identifiers[1]]}
         self.assertDictEqual(expected, pushed)
@@ -806,10 +821,16 @@ class RestoreToCKANTestCase(FederationSuite):
                                          'destination', 'apikey')
         mock_push_dst.assert_any_call(self.catalog, 'org_1',
                                       identifiers[0], 'destination', 'apikey',
-                                      None, False, False, None, None)
+                                      catalog_id=None, demote_superThemes=False,
+                                      demote_themes=False, download_strategy=None,
+                                      generate_new_access_url=None,
+                                      origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE)
         mock_push_dst.assert_any_call(self.catalog, 'org_2',
                                       identifiers[1], 'destination', 'apikey',
-                                      None, False, False, None, None)
+                                      catalog_id=None, demote_superThemes=False,
+                                      demote_themes=False, download_strategy=None,
+                                      generate_new_access_url=None,
+                                      origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE)
         expected = {'org_1': [],
                     'org_2': []}
         self.assertDictEqual(expected, pushed)

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -710,7 +710,7 @@ class RestoreToCKANTestCase(FederationSuite):
         def test_strategy(_catalog, _dist):
             return False
         restore_dataset_to_ckan(self.catalog, 'owner_org',
-                                self.dataset_id,'portal', 'apikey',
+                                self.dataset_id, 'portal', 'apikey',
                                 download_strategy=test_strategy)
         mock_push.assert_called_with(self.catalog, 'owner_org',
                                      self.dataset_id, 'portal', 'apikey',
@@ -741,10 +741,13 @@ class RestoreToCKANTestCase(FederationSuite):
         for identifier in identifiers:
             mock_push_dst.assert_any_call(self.catalog, 'owner_org',
                                           identifier, 'portal', 'apikey',
-                                          catalog_id=None, demote_superThemes=False,
-                                          demote_themes=False, download_strategy=None,
+                                          catalog_id=None,
+                                          demote_superThemes=False,
+                                          demote_themes=False,
+                                          download_strategy=None,
                                           generate_new_access_url=None,
-                                          origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE)
+                                          origin_tz=DEFAULT_TIMEZONE,
+                                          dst_tz=DEFAULT_TIMEZONE)
 
     @patch('pydatajson.federation.push_new_themes')
     def test_restore_failing_organization_to_ckan(self, mock_push_thm,

--- a/tests/test_federation.py
+++ b/tests/test_federation.py
@@ -709,14 +709,18 @@ class RestoreToCKANTestCase(FederationSuite):
     def test_restore_dataset_to_ckan(self, mock_push):
         def test_strategy(_catalog, _dist):
             return False
-        restore_dataset_to_ckan(self.catalog, 'owner_org', self.dataset_id,
-                                'portal', 'apikey', download_strategy=test_strategy)
+        restore_dataset_to_ckan(self.catalog, 'owner_org',
+                                self.dataset_id,'portal', 'apikey',
+                                download_strategy=test_strategy)
         mock_push.assert_called_with(self.catalog, 'owner_org',
                                      self.dataset_id, 'portal', 'apikey',
-                                     catalog_id=None, demote_superThemes=False,
-                                     demote_themes=False, download_strategy=test_strategy,
+                                     catalog_id=None,
+                                     demote_superThemes=False,
+                                     demote_themes=False,
+                                     download_strategy=test_strategy,
                                      generate_new_access_url=None,
-                                     origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE)
+                                     origin_tz=DEFAULT_TIMEZONE,
+                                     dst_tz=DEFAULT_TIMEZONE)
 
     def test_restore_with_numeric_distribution_identifier(self, mock_push):
         bad_catalog = pydatajson.DataJson(self.get_sample(
@@ -756,10 +760,13 @@ class RestoreToCKANTestCase(FederationSuite):
         mock_push_thm.assert_called_with(self.catalog, 'portal', 'apikey')
         mock_push_dst.assert_called_with(self.catalog, 'owner_org',
                                          identifiers[1], 'portal', 'apikey',
-                                         catalog_id=None, demote_superThemes=False,
-                                         demote_themes=False, download_strategy=None,
+                                         catalog_id=None,
+                                         demote_superThemes=False,
+                                         demote_themes=False,
+                                         download_strategy=None,
                                          generate_new_access_url=None,
-                                         origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE)
+                                         origin_tz=DEFAULT_TIMEZONE,
+                                         dst_tz=DEFAULT_TIMEZONE)
 
     @patch('pydatajson.federation.push_new_themes')
     @patch('ckanapi.remoteckan.ActionShortcut')
@@ -777,16 +784,22 @@ class RestoreToCKANTestCase(FederationSuite):
                                          'destination', 'apikey')
         mock_push_dst.assert_any_call(self.catalog, 'org_1',
                                       identifiers[0], 'destination', 'apikey',
-                                      catalog_id=None, demote_superThemes=False,
-                                      demote_themes=False, download_strategy=None,
+                                      catalog_id=None,
+                                      demote_superThemes=False,
+                                      demote_themes=False,
+                                      download_strategy=None,
                                       generate_new_access_url=None,
-                                      origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE)
+                                      origin_tz=DEFAULT_TIMEZONE,
+                                      dst_tz=DEFAULT_TIMEZONE)
         mock_push_dst.assert_any_call(self.catalog, 'org_2',
                                       identifiers[1], 'destination', 'apikey',
-                                      catalog_id=None, demote_superThemes=False,
-                                      demote_themes=False, download_strategy=None,
+                                      catalog_id=None,
+                                      demote_superThemes=False,
+                                      demote_themes=False,
+                                      download_strategy=None,
                                       generate_new_access_url=None,
-                                      origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE)
+                                      origin_tz=DEFAULT_TIMEZONE,
+                                      dst_tz=DEFAULT_TIMEZONE)
         expected = {'org_1': [identifiers[0]],
                     'org_2': [identifiers[1]]}
         self.assertDictEqual(expected, pushed)
@@ -821,16 +834,22 @@ class RestoreToCKANTestCase(FederationSuite):
                                          'destination', 'apikey')
         mock_push_dst.assert_any_call(self.catalog, 'org_1',
                                       identifiers[0], 'destination', 'apikey',
-                                      catalog_id=None, demote_superThemes=False,
-                                      demote_themes=False, download_strategy=None,
+                                      catalog_id=None,
+                                      demote_superThemes=False,
+                                      demote_themes=False,
+                                      download_strategy=None,
                                       generate_new_access_url=None,
-                                      origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE)
+                                      origin_tz=DEFAULT_TIMEZONE,
+                                      dst_tz=DEFAULT_TIMEZONE)
         mock_push_dst.assert_any_call(self.catalog, 'org_2',
                                       identifiers[1], 'destination', 'apikey',
-                                      catalog_id=None, demote_superThemes=False,
-                                      demote_themes=False, download_strategy=None,
+                                      catalog_id=None,
+                                      demote_superThemes=False,
+                                      demote_themes=False,
+                                      download_strategy=None,
                                       generate_new_access_url=None,
-                                      origin_tz=DEFAULT_TIMEZONE, dst_tz=DEFAULT_TIMEZONE)
+                                      origin_tz=DEFAULT_TIMEZONE,
+                                      dst_tz=DEFAULT_TIMEZONE)
         expected = {'org_1': [],
                     'org_2': []}
         self.assertDictEqual(expected, pushed)


### PR DESCRIPTION
Se agrego los parametros opcionales origin_tz y dst_tz para que se usen desde monitoreo.