### PR TITLE
Fields con upper y lower case mixtos se cambian a uppercase

### DIFF
--- a/pydatajson/helpers.py
+++ b/pydatajson/helpers.py
@@ -562,7 +562,8 @@ def fields_to_uppercase(fields):
             uppercase_counts = uppercase_fields.pop(upper_key, 0)
             counts = uppercase_fields.pop(key, 0)
 
-            uppercase_fields[upper_key] = uppercase_counts + lowercase_counts + counts
+            uppercase_fields[upper_key] = \
+                uppercase_counts + lowercase_counts + counts
 
     return uppercase_fields
 

--- a/pydatajson/helpers.py
+++ b/pydatajson/helpers.py
@@ -557,12 +557,12 @@ def fields_to_uppercase(fields):
         lower_key = key.lower()
         upper_key = key.upper()
 
-        if lower_key in fields and lower_key in uppercase_fields:
-            lowercase_counts = fields[lower_key]
-            uppercase_counts = fields.get(upper_key, 0)
+        if not key.isupper():
+            lowercase_counts = uppercase_fields.pop(lower_key, 0)
+            uppercase_counts = uppercase_fields.pop(upper_key, 0)
+            counts = uppercase_fields.pop(key, 0)
 
-            uppercase_fields.pop(lower_key)
-            uppercase_fields[upper_key] = lowercase_counts + uppercase_counts
+            uppercase_fields[upper_key] = uppercase_counts + lowercase_counts + counts
 
     return uppercase_fields
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -267,6 +267,23 @@ class HelpersTestCase(unittest.TestCase):
 
         self.assertEqual(fields_to_uppercase(fields), expected)
 
+    def test_fields_to_uppercase_modifies_mixed__fields(self):
+        fields = {
+            'csv': 5,
+            'Csv': 10,
+            'CSV': 7,
+            'Json': 30,
+            'GeoJSON': 47,
+        }
+
+        expected = {
+            'CSV': 22,
+            'JSON': 30,
+            'GEOJSON': 47
+        }
+
+        self.assertEqual(fields_to_uppercase(fields), expected)
+
     @requests_mock.Mocker()
     def test_validate_valid_url(self, req_mock):
         req_mock.head('http://test.com/')

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -267,7 +267,7 @@ class HelpersTestCase(unittest.TestCase):
 
         self.assertEqual(fields_to_uppercase(fields), expected)
 
-    def test_fields_to_uppercase_modifies_mixed__fields(self):
+    def test_fields_to_uppercase_modifies_mixed_fields(self):
         fields = {
             'csv': 5,
             'Csv': 10,

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -113,7 +113,7 @@ class TestIndicatorsTestCase(object):
                 'CSV': 1,
                 'XLSX': 1,
                 'PDF': 1,
-                'None': 3
+                'NONE': 3
             }
         }
 
@@ -286,7 +286,7 @@ class TestIndicatorsTestCase(object):
                 'CSV': 2,
                 'XLSX': 1,
                 'PDF': 2,
-                'None': 3
+                'NONE': 3
             },
             'distribuciones_tipos_cant': {
                 'file': 1,


### PR DESCRIPTION
Closes https://github.com/datosgobar/monitoreo-apertura/issues/234

- Para el helper `fields_to_uppercase` contemplo el caso de mayusculas y minusculas mixtas en un field, y lo paso a mayusculas
- Creo test para este caso
- Cambio tests para reflejar este cambio