### PR TITLE
Validacion de urls opcional

### DIFF
--- a/pydatajson/core.py
+++ b/pydatajson/core.py
@@ -235,7 +235,7 @@ class DataJson(dict):
 
         logger.warning("No se encontro la distribucion {}.".format(identifier))
 
-    def is_valid_catalog(self, catalog=None):
+    def is_valid_catalog(self, catalog=None, broken_links=False):
         """Valida que un archivo `data.json` cumpla con el schema definido.
 
         Chequea que el data.json tiene todos los campos obligatorios y que
@@ -250,7 +250,7 @@ class DataJson(dict):
             bool: True si el data.json cumple con el schema, sino False.
         """
         catalog = self._read_catalog(catalog) if catalog else self
-        return self.validator.is_valid(catalog)
+        return self.validator.is_valid(catalog, broken_links)
 
     @staticmethod
     def _update_validation_response(error, response):
@@ -290,7 +290,7 @@ class DataJson(dict):
         return new_response
 
     def validate_catalog(self, catalog=None, only_errors=False, fmt="dict",
-                         export_path=None):
+                         export_path=None, broken_links=False):
         """Analiza un data.json registrando los errores que encuentra.
 
         Chequea que el data.json tiene todos los campos obligatorios y que
@@ -342,7 +342,7 @@ class DataJson(dict):
         """
         catalog = self._read_catalog(catalog) if catalog else self
 
-        validation = self.validator.validate_catalog(catalog, only_errors)
+        validation = self.validator.validate_catalog(catalog, only_errors, broken_links)
         if export_path:
             fmt = 'table'
 

--- a/pydatajson/core.py
+++ b/pydatajson/core.py
@@ -342,7 +342,8 @@ class DataJson(dict):
         """
         catalog = self._read_catalog(catalog) if catalog else self
 
-        validation = self.validator.validate_catalog(catalog, only_errors, broken_links)
+        validation = self.validator.validate_catalog(catalog, only_errors,
+                                                     broken_links)
         if export_path:
             fmt = 'table'
 
@@ -962,7 +963,7 @@ El reporte no contiene la clave obligatoria {}. Pruebe con otro archivo.
         catalogs = catalogs or self
         return indicators.generate_catalogs_indicators(
             catalogs, central_catalog, identifier_search=identifier_search,
-            validator=self.validator)
+            validator=self.validator, broken_links=broken_links)
 
     def _count_fields_recursive(self, dataset, fields):
         """Cuenta la información de campos optativos/recomendados/requeridos

--- a/pydatajson/core.py
+++ b/pydatajson/core.py
@@ -957,7 +957,8 @@ El reporte no contiene la clave obligatoria {}. Pruebe con otro archivo.
 
     def generate_catalogs_indicators(self, catalogs=None,
                                      central_catalog=None,
-                                     identifier_search=False):
+                                     identifier_search=False,
+                                     broken_links=False):
         catalogs = catalogs or self
         return indicators.generate_catalogs_indicators(
             catalogs, central_catalog, identifier_search=identifier_search,

--- a/pydatajson/core.py
+++ b/pydatajson/core.py
@@ -250,7 +250,7 @@ class DataJson(dict):
             bool: True si el data.json cumple con el schema, sino False.
         """
         catalog = self._read_catalog(catalog) if catalog else self
-        return self.validator.is_valid(catalog, broken_links)
+        return self.validator.is_valid(catalog, broken_links=broken_links)
 
     @staticmethod
     def _update_validation_response(error, response):

--- a/pydatajson/indicators.py
+++ b/pydatajson/indicators.py
@@ -43,8 +43,14 @@ def generate_numeric_indicators(catalog, validator=None):
                                 only_numeric=True)[1]
 
 
+def generate_urls_indicators(catalog, validator=None):
+    return _generate_indicators(catalog, validator=validator,
+                                broken_links=True)[1]
+
+
 def generate_catalogs_indicators(catalogs, central_catalog=None,
                                  identifier_search=False,
+                                 broken_links=False,
                                  validator=None):
     """Genera una lista de diccionarios con varios indicadores sobre
     los catálogos provistos, tales como la cantidad de datasets válidos,
@@ -82,7 +88,7 @@ def generate_catalogs_indicators(catalogs, central_catalog=None,
             continue
 
         fields_count, result = _generate_indicators(
-            catalog, validator=validator)
+            catalog, validator=validator, broken_links=broken_links)
         if central_catalog:
             result.update(_federation_indicators(
                 catalog, central_catalog, identifier_search=identifier_search))
@@ -111,7 +117,7 @@ def generate_catalogs_indicators(catalogs, central_catalog=None,
     return indicators_list, network_indicators
 
 
-def _generate_indicators(catalog, validator=None, only_numeric=False):
+def _generate_indicators(catalog, validator=None, only_numeric=False, broken_links=False):
     """Genera los indicadores de un catálogo individual.
 
     Args:
@@ -125,6 +131,10 @@ def _generate_indicators(catalog, validator=None, only_numeric=False):
 
     # Obtengo summary para los indicadores del estado de los metadatos
     result.update(_generate_status_indicators(catalog, validator=validator))
+
+    # Genero indicadores relacionados con validacion de urls
+    if broken_links:
+        result.update(_generate_valid_urls_indicators(catalog, validator=validator))
 
     # Genero los indicadores relacionados con fechas, y los agrego
     result.update(
@@ -305,13 +315,6 @@ def _generate_status_indicators(catalog, validator=None):
         'datasets_con_datos_cant': generator.datasets_con_datos_cant(),
         'datasets_sin_datos_cant': generator.datasets_sin_datos_cant(),
         'datasets_con_datos_pct': generator.datasets_con_datos_pct(),
-        'distribuciones_download_url_ok_cant':
-            generator.distribuciones_download_url_ok_cant(),
-        'distribuciones_download_url_error_cant':
-            generator.distribuciones_download_url_error_cant(),
-        'distribuciones_download_url_ok_pct':
-            generator.distribuciones_download_url_ok_pct(),
-
     })
     return result
 
@@ -554,3 +557,34 @@ def count_fields(targets, field):
 
 def _eventual_periodicity(periodicity):
     return periodicity in ('eventual', 'EVENTUAL')
+
+
+def _generate_valid_urls_indicators(catalog, validator=None):
+    """Genera indicadores sobre el estado de las urls de distribuciones
+
+    Args:
+        catalog (dict): diccionario de un data.json parseado
+
+    Returns:
+        dict: indicadores sobre las urls de las distribuciones del catálogo
+    """
+
+    result = {}
+    try:
+        generator = StatusIndicatorsGenerator(catalog, validator=validator)
+    except Exception as e:
+        msg = u'Error generando resumen del catálogo {}: {}'.format(
+            catalog['title'], str(e))
+        logger.warning(msg)
+        return result
+
+    result.update({
+        'distribuciones_download_url_ok_cant':
+            generator.distribuciones_download_url_ok_cant(),
+        'distribuciones_download_url_error_cant':
+            generator.distribuciones_download_url_error_cant(),
+        'distribuciones_download_url_ok_pct':
+            generator.distribuciones_download_url_ok_pct(),
+    })
+
+    return result

--- a/pydatajson/indicators.py
+++ b/pydatajson/indicators.py
@@ -117,7 +117,8 @@ def generate_catalogs_indicators(catalogs, central_catalog=None,
     return indicators_list, network_indicators
 
 
-def _generate_indicators(catalog, validator=None, only_numeric=False, broken_links=False):
+def _generate_indicators(catalog, validator=None, only_numeric=False,
+                         broken_links=False):
     """Genera los indicadores de un catálogo individual.
 
     Args:
@@ -134,7 +135,8 @@ def _generate_indicators(catalog, validator=None, only_numeric=False, broken_lin
 
     # Genero indicadores relacionados con validacion de urls
     if broken_links:
-        result.update(_generate_valid_urls_indicators(catalog, validator=validator))
+        result.update(_generate_valid_urls_indicators(catalog,
+                                                      validator=validator))
 
     # Genero los indicadores relacionados con fechas, y los agrego
     result.update(

--- a/pydatajson/indicators.py
+++ b/pydatajson/indicators.py
@@ -43,11 +43,6 @@ def generate_numeric_indicators(catalog, validator=None):
                                 only_numeric=True)[1]
 
 
-def generate_urls_indicators(catalog, validator=None):
-    return _generate_indicators(catalog, validator=validator,
-                                broken_links=True)[1]
-
-
 def generate_catalogs_indicators(catalogs, central_catalog=None,
                                  identifier_search=False,
                                  broken_links=False,

--- a/pydatajson/validation.py
+++ b/pydatajson/validation.py
@@ -58,12 +58,12 @@ class Validator(object):
         return jsonschema.Draft4Validator(
             schema=schema, resolver=resolver, format_checker=format_checker)
 
-    def is_valid(self, catalog, broken_links):
-        return not self._get_errors(catalog, broken_links)
+    def is_valid(self, catalog, broken_links=False):
+        return not self._get_errors(catalog, broken_links=broken_links)
 
     def validate_catalog(self, catalog, only_errors=False, broken_links=False):
         default_response = self._default_response(catalog)
-        errors = self._get_errors(catalog, broken_links)
+        errors = self._get_errors(catalog, broken_links=broken_links)
 
         response = default_response.copy()
         for error in errors:
@@ -78,12 +78,13 @@ class Validator(object):
 
         return response
 
-    def _get_errors(self, catalog, broken_links):
+    def _get_errors(self, catalog, broken_links=False):
         errors = list(
             self.jsonschema_validator.iter_errors(catalog)
         )
         try:
-            for error in self._custom_errors(catalog, broken_links):
+            for error in self._custom_errors(catalog,
+                                             broken_links=broken_links):
                 errors.append(error)
         except Exception as e:
             logger.warning("Error de validación")

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -8,7 +8,8 @@ import os.path
 
 import requests_mock
 import vcr
-from nose.tools import assert_true, assert_false, assert_equal
+from nose.tools import assert_true, assert_false, assert_equal, \
+    assert_not_in, assert_in
 
 from pydatajson.indicators import _eventual_periodicity
 
@@ -649,3 +650,58 @@ class TestIndicatorsTestCase(object):
         assert_equal(indicators['distribuciones_download_url_ok_cant'], 4)
         assert_equal(indicators['distribuciones_download_url_error_cant'], 2)
         assert_equal(indicators['distribuciones_download_url_ok_pct'], 0.6667)
+
+    def test_indicators_does_not_include_urls_by_default(self):
+        one_catalog = os.path.join(self.SAMPLES_DIR, "several_datasets.json")
+
+        indicator = self.dj.generate_catalogs_indicators([
+            one_catalog,
+        ])[0][0]
+
+        expected = {
+            'datasets_cant': 3,
+            'distribuciones_cant': 6,
+            'datasets_meta_ok_cant': 2,
+            'datasets_meta_error_cant': 1,
+            'datasets_meta_ok_pct': 0.6667,
+            'datasets_con_datos_cant': 2,
+            'datasets_sin_datos_cant': 1,
+            'datasets_con_datos_pct': 0.6667,
+            'datasets_desactualizados_cant': 2,
+            'datasets_actualizados_cant': 1,
+            'datasets_actualizados_pct': 0.3333,
+            'catalogo_ultima_actualizacion_dias': 1279,
+            'datasets_frecuencia_cant': {
+                'R/P1W': 1,
+                'EVENTUAL': 1,
+                'R/P1M': 1
+            },
+            'distribuciones_formatos_cant': {
+                'NONE': 3,
+                'XLSX': 1,
+                'PDF': 1,
+                'CSV': 1
+            },
+            'distribuciones_tipos_cant': {
+                'None': 6
+            },
+            'datasets_licencias_cant': {
+                'None': 3
+            },
+            'campos_recomendados_pct': 0.0972,
+            'campos_optativos_pct': 0.0,
+            'title': 'Cosechando Datos Argentina',
+            'identifier': '7d4d816f-3a40-476e-ab71-d48a3f0eb3c8'
+        }
+
+        not_expected = {
+            'distribuciones_download_url_ok_cant': 4,
+            'distribuciones_download_url_error_cant': 2,
+            'distribuciones_download_url_ok_pct': 0.6667,
+        }
+
+        for k, _ in expected.items():
+            assert_in(k, indicator)
+
+        for k, _ in not_expected.items():
+            assert_not_in(k, indicator)

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -266,8 +266,8 @@ class TestIndicatorsTestCase(object):
 
         indicators, network_indicators = self.dj.generate_catalogs_indicators([
             one_catalog,
-            other_catalog
-        ])
+            other_catalog,
+        ], broken_links=True)
 
         # Esperado: suma de los indicadores individuales
         # No se testean los indicadores de actualización porque las fechas no
@@ -643,8 +643,8 @@ class TestIndicatorsTestCase(object):
 
         catalog = os.path.join(self.SAMPLES_DIR, "several_datasets.json")
 
-        indicators = self.dj.generate_catalogs_indicators(catalog,
-                                                          broken_links=True)[0][0]
+        indicators = self.dj.generate_catalogs_indicators(
+            catalog, broken_links=True)[0][0]
 
         assert_equal(indicators['distribuciones_download_url_ok_cant'], 4)
         assert_equal(indicators['distribuciones_download_url_error_cant'], 2)

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -643,7 +643,8 @@ class TestIndicatorsTestCase(object):
 
         catalog = os.path.join(self.SAMPLES_DIR, "several_datasets.json")
 
-        indicators = self.dj.generate_catalogs_indicators(catalog)[0][0]
+        indicators = self.dj.generate_catalogs_indicators(catalog,
+                                                          broken_links=True)[0][0]
 
         assert_equal(indicators['distribuciones_download_url_ok_cant'], 4)
         assert_equal(indicators['distribuciones_download_url_error_cant'], 2)


### PR DESCRIPTION
Closes https://github.com/datosgobar/monitoreo-apertura/issues/257

- Creo parámetros booleanos para los métodos de validación de catálogos que determinan si validar o no los campos de URLs. Por default no se validan las URL.
- Extraigo generación de indicadores de campos de URLs en función aparte, que crean o no según otro parámetro booleano de la generación de indicadores de catálogos
- Refactorizo tests existentes y agrego uno nuevo para el caso default