### PR TITLE
Cambio la validacion de filenames de una distribucion

### DIFF
--- a/pydatajson/backup.py
+++ b/pydatajson/backup.py
@@ -3,7 +3,8 @@
 
 """Módulo con funciones auxiliares para hacer backups de catálogos.
 
-pydatajson backup https://monitoreo.datos.gob.ar/nodes.json ~/datos-argentina-backup/
+pydatajson backup https://monitoreo.datos.gob.ar/nodes.json
+~/datos-argentina-backup/
 """
 
 from __future__ import unicode_literals

--- a/pydatajson/schemas/distribution.json
+++ b/pydatajson/schemas/distribution.json
@@ -31,7 +31,7 @@
               { "$ref": "mixed-types.json#stringOrNull" },
               { "anyOf": [
                   { "not": { "type": "string" } },
-                  { "pattern": "^[0-9a-zA-Z-._]+$" }
+                  { "pattern": "^.+$" }
                 ]
               }
           ]

--- a/pydatajson/schemas/distribution.json
+++ b/pydatajson/schemas/distribution.json
@@ -26,16 +26,7 @@
          },
         "modified": { "$ref": "mixed-types.json#dateOrDatetimeStringOrNull" },
         "rights": { "$ref": "mixed-types.json#stringOrNull" },
-        "fileName": {
-          "allOf":[
-              { "$ref": "mixed-types.json#stringOrNull" },
-              { "anyOf": [
-                  { "not": { "type": "string" } },
-                  { "pattern": "^.+$" }
-                ]
-              }
-          ]
-        },
+        "fileName": { "$ref": "mixed-types.json#nonEmptyStringOrNull" },
         "field": {
             "type": "array",
             "items": { "$ref": "field.json" }

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -194,11 +194,6 @@ class TestDataJsonTestCase(object):
             ),
             (
                 ['error', 'dataset', 0, 'errors', ],
-                "%s is not valid under any of the given schemas"
-                % jsonschema_str('convocatoriasabiertasduranteela.*o.csv')
-            ),
-            (
-                ['error', 'dataset', 0, 'errors', ],
                 "\[.*\] is not of type %s" % jsonschema_str('object')
             ),
             (


### PR DESCRIPTION
- Cambio el regex del json schema que se usa para la validacion de filenames de distribucion. Ahora acepta cualquier tipo de caracter para el nombre de archivo.
- Elimino error esperado de un caso de test, donde se esperaba un mensaje de error relacionado a un filename invalido.

Closes #299 