### PR TITLE
Validacion ligera filenames

### DIFF
--- a/pydatajson/schemas/distribution.json
+++ b/pydatajson/schemas/distribution.json
@@ -26,7 +26,7 @@
          },
         "modified": { "$ref": "mixed-types.json#dateOrDatetimeStringOrNull" },
         "rights": { "$ref": "mixed-types.json#stringOrNull" },
-        "fileName": { "$ref": "mixed-types.json#nonEmptyStringOrNull" },
+        "fileName": { "$ref": "mixed-types.json#stringOrNull" },
         "field": {
             "type": "array",
             "items": { "$ref": "field.json" }

--- a/pydatajson/validators/consistent_distribution_fields_validator.py
+++ b/pydatajson/validators/consistent_distribution_fields_validator.py
@@ -42,7 +42,7 @@ class ConsistentDistributionFieldsValidator(SimpleValidator):
             file_name = urlparse(distribution[attribute]).path
             extension = os.path.splitext(file_name)[-1].lower()
 
-            if attribute == 'downloadURL' and not extension:
+            if not extension:
                 return True
 
             # hay extensiones exceptuadas porque enmascaran otros formatos

--- a/tests/samples/border_cases_ditribution_filenames.json
+++ b/tests/samples/border_cases_ditribution_filenames.json
@@ -1,0 +1,226 @@
+{
+    "publisher": {
+        "mbox": "datos@modernizacion.gob.ar",
+        "name": "Ministerio de Modernización"
+    },
+    "license": "Open Data Commons Open Database License 1.0",
+    "description": "Portal de Datos Abiertos del Gobierno de la República Argentina",
+    "language": [
+        "spa"
+    ],
+    "title": "Datos Argentina",
+    "issued": "2016-04-14T19:48:05.433640-03:00",
+    "rights": "Derechos especificados en la licencia.",
+    "modified": "2016-04-19T19:48:05.433640-03:00",
+    "dataset": [
+        {
+            "publisher": {
+                "mbox": "onc@modernizacion.gob.ar",
+                "name": "Ministerio de Modernización. Secretaría de Modernización Administrativa. Oficina Nacional de Contrataciones"
+            },
+            "license": "Open Data Commons Open Database License 1.0",
+            "description": "Datos correspondientes al Sistema de Contrataciones Electrónicas (Argentina Compra)",
+            "superTheme": [
+                "econ"
+            ],
+            "title": "Sistema de contrataciones electrónicas",
+            "issued": "2016-04-14T19:48:05.433640-03:00",
+            "temporal": "2015-01-01/2015-12-31",
+            "modified": "2016-04-19T19:48:05.433640-03:00",
+            "language": [
+                "spa"
+            ],
+            "theme": [
+                "contrataciones",
+                "compras",
+                "convocatorias"
+            ],
+            "keyword": [
+                "bienes",
+                "compras",
+                "contrataciones",
+                "bienes y compras"
+            ],
+            "accrualPeriodicity": "R/P1Y",
+            "spatial": "ARG",
+            "identifier": "99db6631-d1c9-470b-a73e-c62daa32c777",
+            "contactPoint": {
+                "hasEmail": "onc-compraselectronicas@modernizacion.gob.ar",
+                "fn": "Ministerio de Modernización. Secretaría de Modernización Administrativa. Oficina Nacional de Contrataciones. Dirección de Compras Electrónicas."
+            },
+            "landingPage": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra",
+            "distribution": [
+                {
+                    "accessURL": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra/archivo/fa3603b3-0af7-43cc-9da9-90a512217d8a",
+                    "identifier": "1.1",
+                    "description": "Listado de las convocatorias abiertas durante el año 2015 en el sistema de contrataciones electrónicas",
+                    "license": "Open Data Commons Open Database License 1.0",
+                    "title": "Convocatorias abiertas durante el año 2015",
+                    "dataset_identifier": "99db6631-d1c9-470b-a73e-c62daa32c777",
+                    "byteSize": 5120,
+                    "type": "file",
+                    "format": "CSV",
+                    "rights": "Derechos especificados en la licencia.",
+                    "mediaType": "text/csv",
+                    "modified": "2016-04-19T19:48:05.433640-03:00",
+                    "downloadURL": "http://186.33.211.253/dataset/99db6631-d1c9-470b-a73e-c62daa32c420/resource/4b7447cb-31ff-4352-96c3-589d212e1cc9/download/convocatorias-abiertas-anio-2015.csv",
+                    "field": [
+                        {
+                            "title": "procedimiento_id",
+                            "type": "integer",
+                            "id": "proc12",
+                            "description": "Identificador único del procedimiento de contratación"
+                        },
+                        {
+                            "type": "integer",
+                            "description": "Identificador único del organismo que realiza la convocatoria. Organismo de máximo nivel jerárquico al que pertenece la unidad operativa de contrataciones.",
+                            "title": "organismo_unidad_operativa_contrataciones_id"
+                        },
+                        {
+                            "type": "integer",
+                            "description": "Identificador único de la unidad operativa de contrataciones",
+                            "title": "unidad_operativa_contrataciones_id"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Organismo que realiza la convocatoria. Organismo de máximo nivel jerárquico al que pertenece la unidad operativa de contrataciones.",
+                            "title": "organismo_unidad_operativa_contrataciones_desc"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Unidad operativa de contrataciones.",
+                            "title": "unidad_operativa_contrataciones_desc"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Tipo de procedimiento al que se adecua la contratación.",
+                            "title": "tipo_procedimiento_contratacion"
+                        },
+                        {
+                            "type": "date",
+                            "description": "Año en el que se inició el proceso de la convocatoria.",
+                            "title": "ejercicio_procedimiento_anio"
+                        },
+                        {
+                            "type": "date",
+                            "description": "Fecha de publicación de la convocatoria en formato AAAA-MM-DD, ISO 8601.",
+                            "title": "fecha_publicacion_convocatoria"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Modalidad bajo la cual se realiza la convocatoria.",
+                            "title": "modalidad_convocatoria"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Clase de la convocatoria.",
+                            "title": "clase_convocatoria"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Objeto/objetivo de la convocatoria",
+                            "title": "objeto_convocatoria"
+                        }
+                    ],
+                    "issued": "2016-04-14T19:48:05.433640-03:00",
+                    "fileName": ""
+                }
+            ],
+            "source": "Ministerio de modernizacion"
+        },
+        {
+            "publisher": {
+                "mbox": "onc@modernizacion.gob.ar",
+                "name": "Ministerio de Modernización. Secretaría de Modernización Administrativa. Oficina Nacional de Contrataciones"
+            },
+            "license": "Open Data Commons Open Database License 1.0",
+            "description": "Datos correspondientes al Sistema de Contrataciones Electrónicas (Argentina Compra) (sin datos)",
+            "superTheme": [
+                "ECON"
+            ],
+            "title": "Sistema de contrataciones electrónicas (sin datos)",
+            "issued": "2016-04-14T19:48:05.433640-03:00",
+            "temporal": "2015-01-01/2015-12-31",
+            "modified": "2016-04-19T19:48:05.433640-03:00",
+            "language": [
+                "spa"
+            ],
+            "theme": [
+                "contrataciones",
+                "compras",
+                "convocatorias"
+            ],
+            "keyword": [
+                "bienes",
+                "compras",
+                "contrataciones",
+                "bienes y compras"
+            ],
+            "accrualPeriodicity": "R/P1Y",
+            "spatial": "ARG",
+            "identifier": "99db6631-d1c9-470b-a73e-c62daa32c420",
+            "contactPoint": {
+                "hasEmail": "onc-compraselectronicas@modernizacion.gob.ar",
+                "fn": "Ministerio de Modernización. Secretaría de Modernización Administrativa. Oficina Nacional de Contrataciones. Dirección de Compras Electrónicas."
+            },
+            "landingPage": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra",
+            "distribution": [
+                {
+                    "accessURL": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra/archivo/fa3603b3-0af7-43cc-9da9-90a512217d8a",
+                    "identifier": "d_7d4d816f-3a40-476e-ab71-d48a3f0eb3c8",
+                    "description": "Listado de las convocatorias abiertas durante el año 2015 en el sistema de contrataciones electrónicas",
+                    "license": "Open Data Commons Open Database License 1.0",
+                    "title": "Convocatorias abiertas durante el año 2015",
+                    "dataset_identifier": "99db6631-d1c9-470b-a73e-c62daa32c420",
+                    "byteSize": 5120,
+                    "type": "documentation",
+                    "format": "PDF",
+                    "rights": "Derechos especificados en la licencia.",
+                    "mediaType": "application/pdf",
+                    "modified": "2016-04-19T19:48:05.433640-03:00",
+                    "downloadURL": "http://186.33.211.253/dataset/99db6631-d1c9-470b-a73e-c62daa32c420/resource/4b7447cb-31ff-4352-96c3-589d212e1cc9/download/convocatorias-abiertas-anio-2015.pdf",
+                    "issued": "2016-04-14T19:48:05.433640-03:00",
+                    "fileName": null
+                }
+            ],
+            "source": "Ministerio de modernizacion"
+        }
+    ],
+    "identifier": "7d4d816f-3a40-476e-ab71-d48a3f0eb3c8",
+    "version": "1.1",
+    "spatial": "ARG",
+    "superThemeTaxonomy": "http://datos.gob.ar/superThemeTaxonomy.json",
+    "themeTaxonomy": [
+        {
+            "label": "Convocatorias",
+            "description": "Datasets sobre licitaciones en estado de convocatoria.",
+            "id": "convocatorias"
+        },
+        {
+            "label": "Adquisición",
+            "description": "Datasets sobre compras realizadas.",
+            "id": "compras"
+        },
+        {
+            "label": "Contrataciones",
+            "description": "Datasets sobre contrataciones.",
+            "id": "contrataciones"
+        },
+        {
+            "label": "Adjudicaciones",
+            "description": "Datasets sobre licitaciones adjudicadas.",
+            "id": "adjudicaciones"
+        },
+        {
+            "label": "Normativa",
+            "description": "Datasets sobre normativa para compras y contrataciones.",
+            "id": "normativa"
+        },
+        {
+            "label": "Proveeduría",
+            "description": "Datasets sobre proveedores del Estado.",
+            "id": "proveedores"
+        }
+    ],
+    "homepage": "http://datos.gob.ar"
+}

--- a/tests/samples/invalid_ditribution_filenames.json
+++ b/tests/samples/invalid_ditribution_filenames.json
@@ -1,0 +1,169 @@
+{
+    "publisher": {
+        "mbox": "datos@modernizacion.gob.ar",
+        "name": "Ministerio de Modernización"
+    },
+    "license": "Open Data Commons Open Database License 1.0",
+    "description": "Portal de Datos Abiertos del Gobierno de la República Argentina",
+    "language": [
+        "spa"
+    ],
+    "title": "Datos Argentina",
+    "issued": "2016-04-14T19:48:05.433640-03:00",
+    "rights": "Derechos especificados en la licencia.",
+    "modified": "2016-04-19T19:48:05.433640-03:00",
+    "dataset": [
+        {
+            "publisher": {
+                "mbox": "onc@modernizacion.gob.ar",
+                "name": "Ministerio de Modernización. Secretaría de Modernización Administrativa. Oficina Nacional de Contrataciones"
+            },
+            "license": "Open Data Commons Open Database License 1.0",
+            "description": "Datos correspondientes al Sistema de Contrataciones Electrónicas (Argentina Compra)",
+            "superTheme": [
+                "econ"
+            ],
+            "title": "Sistema de contrataciones electrónicas",
+            "issued": "2016-04-14T19:48:05.433640-03:00",
+            "temporal": "2015-01-01/2015-12-31",
+            "modified": "2016-04-19T19:48:05.433640-03:00",
+            "language": [
+                "spa"
+            ],
+            "theme": [
+                "contrataciones",
+                "compras",
+                "convocatorias"
+            ],
+            "keyword": [
+                "bienes",
+                "compras",
+                "contrataciones",
+                "bienes y compras"
+            ],
+            "accrualPeriodicity": "R/P1Y",
+            "spatial": "ARG",
+            "identifier": "99db6631-d1c9-470b-a73e-c62daa32c777",
+            "contactPoint": {
+                "hasEmail": "onc-compraselectronicas@modernizacion.gob.ar",
+                "fn": "Ministerio de Modernización. Secretaría de Modernización Administrativa. Oficina Nacional de Contrataciones. Dirección de Compras Electrónicas."
+            },
+            "landingPage": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra",
+            "distribution": [
+                {
+                    "accessURL": "http://datos.gob.ar/dataset/sistema-de-contrataciones-electronicas-argentina-compra/archivo/fa3603b3-0af7-43cc-9da9-90a512217d8a",
+                    "identifier": "1.1",
+                    "description": "Listado de las convocatorias abiertas durante el año 2015 en el sistema de contrataciones electrónicas",
+                    "license": "Open Data Commons Open Database License 1.0",
+                    "title": "Convocatorias abiertas durante el año 2015",
+                    "dataset_identifier": "99db6631-d1c9-470b-a73e-c62daa32c777",
+                    "byteSize": 5120,
+                    "type": "file",
+                    "format": "CSV",
+                    "rights": "Derechos especificados en la licencia.",
+                    "mediaType": "text/csv",
+                    "modified": "2016-04-19T19:48:05.433640-03:00",
+                    "downloadURL": "http://186.33.211.253/dataset/99db6631-d1c9-470b-a73e-c62daa32c420/resource/4b7447cb-31ff-4352-96c3-589d212e1cc9/download/convocatorias-abiertas-anio-2015.csv",
+                    "field": [
+                        {
+                            "title": "procedimiento_id",
+                            "type": "integer",
+                            "id": "proc12",
+                            "description": "Identificador único del procedimiento de contratación"
+                        },
+                        {
+                            "type": "integer",
+                            "description": "Identificador único del organismo que realiza la convocatoria. Organismo de máximo nivel jerárquico al que pertenece la unidad operativa de contrataciones.",
+                            "title": "organismo_unidad_operativa_contrataciones_id"
+                        },
+                        {
+                            "type": "integer",
+                            "description": "Identificador único de la unidad operativa de contrataciones",
+                            "title": "unidad_operativa_contrataciones_id"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Organismo que realiza la convocatoria. Organismo de máximo nivel jerárquico al que pertenece la unidad operativa de contrataciones.",
+                            "title": "organismo_unidad_operativa_contrataciones_desc"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Unidad operativa de contrataciones.",
+                            "title": "unidad_operativa_contrataciones_desc"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Tipo de procedimiento al que se adecua la contratación.",
+                            "title": "tipo_procedimiento_contratacion"
+                        },
+                        {
+                            "type": "date",
+                            "description": "Año en el que se inició el proceso de la convocatoria.",
+                            "title": "ejercicio_procedimiento_anio"
+                        },
+                        {
+                            "type": "date",
+                            "description": "Fecha de publicación de la convocatoria en formato AAAA-MM-DD, ISO 8601.",
+                            "title": "fecha_publicacion_convocatoria"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Modalidad bajo la cual se realiza la convocatoria.",
+                            "title": "modalidad_convocatoria"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Clase de la convocatoria.",
+                            "title": "clase_convocatoria"
+                        },
+                        {
+                            "type": "string",
+                            "description": "Objeto/objetivo de la convocatoria",
+                            "title": "objeto_convocatoria"
+                        }
+                    ],
+                    "issued": "2016-04-14T19:48:05.433640-03:00",
+                    "fileName": 4
+                }
+            ],
+            "source": "Ministerio de modernizacion"
+        }
+    ],
+    "identifier": "7d4d816f-3a40-476e-ab71-d48a3f0eb3c8",
+    "version": "1.1",
+    "spatial": "ARG",
+    "superThemeTaxonomy": "http://datos.gob.ar/superThemeTaxonomy.json",
+    "themeTaxonomy": [
+        {
+            "label": "Convocatorias",
+            "description": "Datasets sobre licitaciones en estado de convocatoria.",
+            "id": "convocatorias"
+        },
+        {
+            "label": "Adquisición",
+            "description": "Datasets sobre compras realizadas.",
+            "id": "compras"
+        },
+        {
+            "label": "Contrataciones",
+            "description": "Datasets sobre contrataciones.",
+            "id": "contrataciones"
+        },
+        {
+            "label": "Adjudicaciones",
+            "description": "Datasets sobre licitaciones adjudicadas.",
+            "id": "adjudicaciones"
+        },
+        {
+            "label": "Normativa",
+            "description": "Datasets sobre normativa para compras y contrataciones.",
+            "id": "normativa"
+        },
+        {
+            "label": "Proveeduría",
+            "description": "Datasets sobre proveedores del Estado.",
+            "id": "proveedores"
+        }
+    ],
+    "homepage": "http://datos.gob.ar"
+}

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -8,7 +8,7 @@ import re
 
 import requests_mock
 import vcr
-from nose.tools import assert_true, assert_false, assert_dict_equal,\
+from nose.tools import assert_true, assert_false, assert_dict_equal, \
     assert_regexp_matches
 from six import iteritems, text_type
 
@@ -117,6 +117,20 @@ class TestDataJsonTestCase(object):
         expected_valid = False
         path = ['error', 'dataset', 0, 'errors', 0, 'message']
         regex = "\[\] is too short"
+        self.validate_message_with_file(
+            case_filename, expected_valid, path, regex)
+
+    def test_valid_empty_filename_list(self):
+        case_filename = "border_cases_ditribution_filenames"
+        expected_valid = True
+        sample_path = os.path.join(self.SAMPLES_DIR, case_filename + ".json")
+        self.validate_valid(sample_path, expected_valid)
+
+    def test_invalid_numeric_filename_list(self):
+        case_filename = "invalid_ditribution_filenames"
+        expected_valid = False
+        path = ['error', 'dataset', 0, 'errors', 0, 'message']
+        regex = "4 is not valid under any of the given schemas"
         self.validate_message_with_file(
             case_filename, expected_valid, path, regex)
 


### PR DESCRIPTION
Se deja que la validación de filenames de distribuciones puedan ser vacios o null, casos como números deben fallar.

closes #299 